### PR TITLE
Rest of the Current DSNP Schemas

### DIFF
--- a/dsnp/broadcast.spec.ts
+++ b/dsnp/broadcast.spec.ts
@@ -1,52 +1,14 @@
-import fs from "fs";
-import { ParquetWriter } from "@dsnp/parquetjs";
-import { transformToParquetjs } from "../helpers/parquet";
-import broadcastSchema from "./broadcast";
+import { testCompression, testParquetSchema } from "../helpers/parquet";
 import * as generators from "@dsnp/test-generators";
-import { ParquetModel } from "../types/frequency";
+import broadcastSchema from "./broadcast";
 
 describe("Broadcast Spec", () => {
-  it("can build a parquet file", async () => {
-    await expect(async () => {
-      const [schema, bloom] = transformToParquetjs(broadcastSchema);
-      await ParquetWriter.openStream(
-        schema,
-        {
-          write: jest.fn(),
-          end: jest.fn(),
-        },
-        { bloomFilters: bloom }
-      );
-    }).not.toThrow();
-  });
+  testParquetSchema(broadcastSchema);
 
-  it("Compressing all columns is best", async () => {
-    const defaultSize = await generateParquetTestFileSize(broadcastSchema, 100);
-
-    for (const idx in broadcastSchema) {
-      const testSchema = [...broadcastSchema];
-      testSchema[idx].compression = "UNCOMPRESSED";
-      const uncompressedSize = await generateParquetTestFileSize(testSchema, 100);
-      expect(defaultSize).toBeLessThan(uncompressedSize);
-    }
-  });
+  testCompression("broadcast", broadcastSchema, () => ({
+    announcementType: 2,
+    contentHash: generators.generateHash(),
+    fromId: generators.randInt(10000000),
+    url: `https://www.imadapp.com/data/posts/${generators.generateHash()}`,
+  }));
 });
-
-const generateParquetTestFileSize = async (rawSchema: ParquetModel, count: number): Promise<number> => {
-  const [schema, bloom] = transformToParquetjs(rawSchema);
-  const path = "./test-broadcast-size.parquet";
-  const writer = await ParquetWriter.openFile(schema, path, { bloomFilters: bloom });
-
-  for (let i = 0; i < count; i++) {
-    await writer.appendRow({
-      announcementType: 2,
-      contentHash: generators.generateHash(),
-      fromId: generators.randInt(10000000),
-      url: `https://www.imadapp.com/data/posts/${generators.generateHash()}`,
-    });
-  }
-  await writer.close();
-  const size = fs.statSync(path).size;
-  fs.rmSync(path);
-  return size;
-};

--- a/dsnp/broadcast.ts
+++ b/dsnp/broadcast.ts
@@ -5,8 +5,8 @@ const broadcast: ParquetModel = [
     name: "announcementType",
     column_type: {
       INTEGER: {
-        bit_width: 16,
-        sign: false,
+        bit_width: 32,
+        sign: true,
       },
     },
     compression: "GZIP",

--- a/dsnp/profile.spec.ts
+++ b/dsnp/profile.spec.ts
@@ -1,0 +1,14 @@
+import { testCompression, testParquetSchema } from "../helpers/parquet";
+import * as generators from "@dsnp/test-generators";
+import profileSchema from "./profile";
+
+describe("Profile Spec", () => {
+  testParquetSchema(profileSchema);
+
+  testCompression("profile", profileSchema, () => ({
+    announcementType: 5,
+    contentHash: generators.generateHash(),
+    fromId: generators.randInt(10000000),
+    url: `https://www.imadapp.com/data/posts/${generators.generateHash()}`,
+  }));
+});

--- a/dsnp/profile.ts
+++ b/dsnp/profile.ts
@@ -1,0 +1,40 @@
+import { ParquetModel } from "../types/frequency";
+
+const profile: ParquetModel = [
+  {
+    name: "announcementType",
+    column_type: {
+      INTEGER: {
+        bit_width: 16,
+        sign: false,
+      },
+    },
+    compression: "GZIP",
+    bloom_filter: false,
+  },
+  {
+    name: "contentHash",
+    column_type: "BYTE_ARRAY",
+    compression: "GZIP",
+    bloom_filter: true,
+  },
+  {
+    name: "fromId",
+    column_type: {
+      INTEGER: {
+        bit_width: 64,
+        sign: false,
+      },
+    },
+    compression: "GZIP",
+    bloom_filter: true,
+  },
+  {
+    name: "url",
+    column_type: "STRING",
+    compression: "GZIP",
+    bloom_filter: false,
+  },
+];
+
+export default profile;

--- a/dsnp/profile.ts
+++ b/dsnp/profile.ts
@@ -5,8 +5,8 @@ const profile: ParquetModel = [
     name: "announcementType",
     column_type: {
       INTEGER: {
-        bit_width: 16,
-        sign: false,
+        bit_width: 32,
+        sign: true,
       },
     },
     compression: "GZIP",

--- a/dsnp/reaction.spec.ts
+++ b/dsnp/reaction.spec.ts
@@ -1,0 +1,15 @@
+import { testCompression, testParquetSchema } from "../helpers/parquet";
+import * as generators from "@dsnp/test-generators";
+import reactionSchema from "./reaction";
+
+describe("Reaction Spec", () => {
+  testParquetSchema(reactionSchema);
+
+  testCompression("reaction", reactionSchema, () => ({
+    announcementType: 4,
+    emoji: generators.sample(["😀", "🤌🏼", "👩🏻‍🎤", "🧑🏿‍🏫", "🏳️‍🌈", "🏳️‍⚧️", "⚛︎", "🃑", "♻︎"]),
+    apply: generators.randInt(255),
+    fromId: generators.randInt(10000000),
+    inReplyTo: `dsnp://${generators.randInt(10000000)}/${generators.generateHash()}`,
+  }));
+});

--- a/dsnp/reaction.ts
+++ b/dsnp/reaction.ts
@@ -5,8 +5,8 @@ const reaction: ParquetModel = [
     name: "announcementType",
     column_type: {
       INTEGER: {
-        bit_width: 16,
-        sign: false,
+        bit_width: 32,
+        sign: true,
       },
     },
     compression: "GZIP",

--- a/dsnp/reaction.ts
+++ b/dsnp/reaction.ts
@@ -1,0 +1,51 @@
+import { ParquetModel } from "../types/frequency";
+
+const reaction: ParquetModel = [
+  {
+    name: "announcementType",
+    column_type: {
+      INTEGER: {
+        bit_width: 16,
+        sign: false,
+      },
+    },
+    compression: "GZIP",
+    bloom_filter: false,
+  },
+  {
+    name: "emoji",
+    column_type: "STRING",
+    compression: "GZIP",
+    bloom_filter: true,
+  },
+  {
+    name: "apply",
+    column_type: {
+      INTEGER: {
+        bit_width: 8,
+        sign: false,
+      },
+    },
+    compression: "GZIP",
+    bloom_filter: false,
+  },
+  {
+    name: "fromId",
+    column_type: {
+      INTEGER: {
+        bit_width: 64,
+        sign: false,
+      },
+    },
+    compression: "GZIP",
+    bloom_filter: true,
+  },
+  {
+    name: "inReplyTo",
+    column_type: "STRING",
+    compression: "GZIP",
+    bloom_filter: true,
+  },
+];
+
+export default reaction;

--- a/dsnp/reply.spec.ts
+++ b/dsnp/reply.spec.ts
@@ -1,0 +1,15 @@
+import { testCompression, testParquetSchema } from "../helpers/parquet";
+import * as generators from "@dsnp/test-generators";
+import replySchema from "./reply";
+
+describe("Reply Spec", () => {
+  testParquetSchema(replySchema);
+
+  testCompression("reply", replySchema, () => ({
+    announcementType: 3,
+    contentHash: generators.generateHash(),
+    fromId: generators.randInt(10000000),
+    inReplyTo: `dsnp://${generators.randInt(10000000)}/${generators.generateHash()}`,
+    url: `https://www.imadapp.com/data/posts/${generators.generateHash()}`,
+  }));
+});

--- a/dsnp/reply.ts
+++ b/dsnp/reply.ts
@@ -5,8 +5,8 @@ const reply: ParquetModel = [
     name: "announcementType",
     column_type: {
       INTEGER: {
-        bit_width: 16,
-        sign: false,
+        bit_width: 32,
+        sign: true,
       },
     },
     compression: "GZIP",

--- a/dsnp/reply.ts
+++ b/dsnp/reply.ts
@@ -1,0 +1,46 @@
+import { ParquetModel } from "../types/frequency";
+
+const reply: ParquetModel = [
+  {
+    name: "announcementType",
+    column_type: {
+      INTEGER: {
+        bit_width: 16,
+        sign: false,
+      },
+    },
+    compression: "GZIP",
+    bloom_filter: false,
+  },
+  {
+    name: "contentHash",
+    column_type: "BYTE_ARRAY",
+    compression: "GZIP",
+    bloom_filter: true,
+  },
+  {
+    name: "fromId",
+    column_type: {
+      INTEGER: {
+        bit_width: 64,
+        sign: false,
+      },
+    },
+    compression: "GZIP",
+    bloom_filter: true,
+  },
+  {
+    name: "inReplyTo",
+    column_type: "STRING",
+    compression: "GZIP",
+    bloom_filter: true,
+  },
+  {
+    name: "url",
+    column_type: "STRING",
+    compression: "GZIP",
+    bloom_filter: false,
+  },
+];
+
+export default reply;

--- a/dsnp/tombstone.spec.ts
+++ b/dsnp/tombstone.spec.ts
@@ -1,0 +1,14 @@
+import { testCompression, testParquetSchema } from "../helpers/parquet";
+import * as generators from "@dsnp/test-generators";
+import tombstoneSchema from "./tombstone";
+
+describe("Tombstone Spec", () => {
+  testParquetSchema(tombstoneSchema);
+
+  testCompression("tombstone", tombstoneSchema, () => ({
+    announcementType: 0,
+    fromId: generators.randInt(10000000),
+    targetAnnouncementType: 2,
+    targetContentHash: generators.generateHash(),
+  }));
+});

--- a/dsnp/tombstone.ts
+++ b/dsnp/tombstone.ts
@@ -5,8 +5,8 @@ const tombstone: ParquetModel = [
     name: "announcementType",
     column_type: {
       INTEGER: {
-        bit_width: 16,
-        sign: false,
+        bit_width: 32,
+        sign: true,
       },
     },
     compression: "GZIP",
@@ -27,8 +27,8 @@ const tombstone: ParquetModel = [
     name: "targetAnnouncementType",
     column_type: {
       INTEGER: {
-        bit_width: 16,
-        sign: false,
+        bit_width: 32,
+        sign: true,
       },
     },
     compression: "GZIP",

--- a/dsnp/tombstone.ts
+++ b/dsnp/tombstone.ts
@@ -1,0 +1,45 @@
+import { ParquetModel } from "../types/frequency";
+
+const tombstone: ParquetModel = [
+  {
+    name: "announcementType",
+    column_type: {
+      INTEGER: {
+        bit_width: 16,
+        sign: false,
+      },
+    },
+    compression: "GZIP",
+    bloom_filter: false,
+  },
+  {
+    name: "fromId",
+    column_type: {
+      INTEGER: {
+        bit_width: 64,
+        sign: false,
+      },
+    },
+    compression: "GZIP",
+    bloom_filter: true,
+  },
+  {
+    name: "targetAnnouncementType",
+    column_type: {
+      INTEGER: {
+        bit_width: 16,
+        sign: false,
+      },
+    },
+    compression: "GZIP",
+    bloom_filter: false,
+  },
+  {
+    name: "targetContentHash",
+    column_type: "BYTE_ARRAY",
+    compression: "GZIP",
+    bloom_filter: true,
+  },
+];
+
+export default tombstone;

--- a/dsnp/update.spec.ts
+++ b/dsnp/update.spec.ts
@@ -1,0 +1,15 @@
+import { testCompression, testParquetSchema } from "../helpers/parquet";
+import * as generators from "@dsnp/test-generators";
+import updateSchema from "./update";
+
+describe("Update Spec", () => {
+  testParquetSchema(updateSchema);
+
+  testCompression("update", updateSchema, () => ({
+    announcementType: 6,
+    contentHash: generators.generateHash(),
+    fromId: generators.randInt(10000000),
+    targetContentHash: generators.generateHash(),
+    url: `https://www.imadapp.com/data/posts/${generators.generateHash()}`,
+  }));
+});

--- a/dsnp/update.ts
+++ b/dsnp/update.ts
@@ -5,8 +5,8 @@ const update: ParquetModel = [
     name: "announcementType",
     column_type: {
       INTEGER: {
-        bit_width: 16,
-        sign: false,
+        bit_width: 32,
+        sign: true,
       },
     },
     compression: "GZIP",

--- a/dsnp/update.ts
+++ b/dsnp/update.ts
@@ -1,0 +1,46 @@
+import { ParquetModel } from "../types/frequency";
+
+const update: ParquetModel = [
+  {
+    name: "announcementType",
+    column_type: {
+      INTEGER: {
+        bit_width: 16,
+        sign: false,
+      },
+    },
+    compression: "GZIP",
+    bloom_filter: false,
+  },
+  {
+    name: "contentHash",
+    column_type: "BYTE_ARRAY",
+    compression: "GZIP",
+    bloom_filter: true,
+  },
+  {
+    name: "fromId",
+    column_type: {
+      INTEGER: {
+        bit_width: 64,
+        sign: false,
+      },
+    },
+    compression: "GZIP",
+    bloom_filter: true,
+  },
+  {
+    name: "url",
+    column_type: "STRING",
+    compression: "GZIP",
+    bloom_filter: false,
+  },
+  {
+    name: "targetContentHash",
+    column_type: "BYTE_ARRAY",
+    compression: "GZIP",
+    bloom_filter: true,
+  },
+];
+
+export default update;

--- a/helpers/parquet.ts
+++ b/helpers/parquet.ts
@@ -1,7 +1,10 @@
-import { ParquetSchema } from "@dsnp/parquetjs";
+/* eslint-disable jest/no-export */
+import fs from "fs";
+import { ParquetSchema, ParquetWriter } from "@dsnp/parquetjs";
 import { FrequencyParquetType, ParquetModel } from "../types/frequency";
 
 type BloomFilterColumn = { column: string };
+type RowGenerator = () => Record<string, unknown>;
 
 const convertColumnType = (columnType: FrequencyParquetType): string => {
   if (typeof columnType === "string") {
@@ -19,7 +22,7 @@ const convertColumnType = (columnType: FrequencyParquetType): string => {
   throw new Error("Not currently supported in transformation");
 };
 
-export const transformToParquetjs = (frequencySchema: ParquetModel): [ParquetSchema, BloomFilterColumn[]] => {
+const transformToParquetjs = (frequencySchema: ParquetModel): [ParquetSchema, BloomFilterColumn[]] => {
   const schema = Object.fromEntries(
     frequencySchema.map((column) => {
       return [
@@ -36,4 +39,52 @@ export const transformToParquetjs = (frequencySchema: ParquetModel): [ParquetSch
 
   /* eslint-disable @typescript-eslint/no-explicit-any */
   return [new ParquetSchema(schema as any), bloomFilters];
+};
+
+export const testParquetSchema = async (model: ParquetModel) => {
+  test("can build a parquet file", async () => {
+    await expect(async () => {
+      const [schema, bloom] = transformToParquetjs(model);
+      await ParquetWriter.openStream(
+        schema,
+        {
+          write: jest.fn(),
+          end: jest.fn(),
+        },
+        { bloomFilters: bloom }
+      );
+    }).not.toThrow();
+  });
+};
+
+export const testCompression = async (name: string, model: ParquetModel, rowGenerator: RowGenerator) => {
+  test("Compressing all columns is best", async () => {
+    const defaultSize = await generateParquetTestFileSize(name, model, 100, rowGenerator);
+
+    for (const idx in model) {
+      const testSchema = [...model];
+      testSchema[idx].compression = "UNCOMPRESSED";
+      const uncompressedSize = await generateParquetTestFileSize(name, testSchema, 100, rowGenerator);
+      expect(defaultSize).toBeLessThan(uncompressedSize);
+    }
+  });
+};
+
+const generateParquetTestFileSize = async (
+  name: string,
+  rawSchema: ParquetModel,
+  count: number,
+  rowGenerator: RowGenerator
+): Promise<number> => {
+  const [schema, bloom] = transformToParquetjs(rawSchema);
+  const path = `./test-${name}-size.parquet`;
+  const writer = await ParquetWriter.openFile(schema, path, { bloomFilters: bloom });
+
+  for (let i = 0; i < count; i++) {
+    await writer.appendRow(rowGenerator());
+  }
+  await writer.close();
+  const size = fs.statSync(path).size;
+  fs.rmSync(path);
+  return size;
 };


### PR DESCRIPTION
Problem
=======
Need to define the Frequency Schemas for the rest of the current DSNP Announcement Types

Part of https://github.com/LibertyDSNP/spec/issues/191

Solution
========

- Refactored the Parquet Tests to make them reusable
- Added the schemas for:
  - Update
  - Reply
  - Reaction
  - Tombstone
  - Profile

Steps to Verify:
----------------
1. Run the tests
1. Each announcement should match the spec here: https://spec.dsnp.org/DSNP/Announcements.html
