### PR TITLE
Updated versions of API augment and Polkadot

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
   },
   "homepage": "https://github.com/LibertyDSNP/schemas#readme",
   "dependencies": {
-    "@frequency-chain/api-augment": "^0.9.29-rc1",
-    "@polkadot/api": "^9.3.3",
+    "@frequency-chain/api-augment": "^0.9.29-2",
+    "@polkadot/api": "^9.10.2",
     "@polkadot/extension-dapp": "^0.44.6",
-    "@polkadot/types": "^9.3.3",
+    "@polkadot/types": "^9.10.2",
     "jest-environment-jsdom": "^29.0.3",
     "ts-node": "^10.8.1",
     "typescript": "^4.7.4"


### PR DESCRIPTION
Updated API augment to 0.9.29-2 and Polkadot to 9.10.2

Problem
=======
problem statement

Closes: <!-- GitHub Issue  ->

Solution
========
What I/we did to solve this problem

with @pairperson1

Double Checks:
---------------
- [] Did you update the changelog?
- [] Do you have good documentation on exported methods?

Change summary:
---------------
* Tidy, well formulated commit message
* Another great commit message
* Something else I/we did

Steps to Verify:
----------------
1. A setup step / beginning state
1. What to do next
1. Any other instructions
1. Expected behavior
1. Suggestions for testing
