### PR TITLE
Add schema read tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,70 @@ To register a single schema:
 e.g. To register the "profile" schema
 
     npm run deploy profile
+
+# Additional Tools
+
+## Read all Schemas from a Chain
+
+```
+DEPLOY_SCHEMA_ENDPOINT_URL="ws://127.0.0.1:9944" npm run read
+```
+
+Will output various information about the schemas on the chain as well as attempt to match known DSNP schemas.
+
+### Example Output
+
+```
+## Connection Information
+┌─────────┬─────────────────────┬────────────────────────────────────────────┐
+│ (index) │         key         │                   value                    │
+├─────────┼─────────────────────┼────────────────────────────────────────────┤
+│    0    │    'endpointUrl'    │ 'wss://frequency-seal.liberti.social:9944' │
+│    1    │   'clientVersion'   │            '0.1.0-377bbe37fbe'             │
+│    2    │     'specName'      │             'frequency-rococo'             │
+│    3    │    'specVersion'    │                    '1'                     │
+│    4    │ 'latestBlockNumber' │                    '16'                    │
+└─────────┴─────────────────────┴────────────────────────────────────────────┘
+
+## Schema Information
+There are 8 schemas on the connected chain.
+
+## Schema Id 1
+┌─────────┬──────────────────────┬───────────────────────────────┐
+│ (index) │         key          │             value             │
+├─────────┼──────────────────────┼───────────────────────────────┤
+│    0    │     'schema_id'      │              '1'              │
+│    1    │     'model_type'     │           'Parquet'           │
+│    2    │  'payload_location'  │            'IPFS'             │
+│    3    │ 'matchesDSNPSchemas' │ 'dsnp.broadcast,dsnp.profile' │
+└─────────┴──────────────────────┴───────────────────────────────┘
+
+## Schema Model
+[
+  {
+    "name": "announcementType",
+    "column_type": {"INTEGER": {"bit_width": 32, "sign": true}},
+    "compression": "GZIP",
+    "bloom_filter": false
+  },
+  {
+    "name": "contentHash",
+    "column_type": "BYTE_ARRAY",
+    "compression": "GZIP",
+    "bloom_filter": true
+  },
+  {
+    "name": "fromId",
+    "column_type": {"INTEGER": {"bit_width": 64, "sign": false}},
+    "compression": "GZIP",
+    "bloom_filter": true
+  },
+  {
+    "name": "url",
+    "column_type": "STRING",
+    "compression": "GZIP",
+    "bloom_filter": false
+  }
+]
+...
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,12 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@frequency-chain/api-augment": "^0.9.29-2",
+        "@frequency-chain/api-augment": "0.9.29-2",
         "@polkadot/api": "^9.10.2",
         "@polkadot/extension-dapp": "^0.44.6",
         "@polkadot/types": "^9.10.2",
         "jest-environment-jsdom": "^29.0.3",
+        "json-stringify-pretty-compact": "^3.0.0",
         "ts-node": "^10.8.1",
         "typescript": "^4.7.4"
       },
@@ -695,9 +696,14 @@
       }
     },
     "node_modules/@frequency-chain/api-augment": {
-      "version": "0.9.29-rc1",
-      "resolved": "https://registry.npmjs.org/@frequency-chain/api-augment/-/api-augment-0.9.29-rc1.tgz",
-      "integrity": "sha512-RvXrkt6uqNCBfgmlL5qbAS1P/7lrQ3oJZmcd6KZF8bxSGEUYDqF2k2e2QPfpzrMxugkNSfCa73TbGVF0lEvhsA=="
+      "version": "0.9.29-2",
+      "resolved": "https://registry.npmjs.org/@frequency-chain/api-augment/-/api-augment-0.9.29-2.tgz",
+      "integrity": "sha512-SqHzOAkIfdTZxiPN5jYB1LJJi7X1K1XrTN/hCAur0Yce2I2+lfjFOdCLFbw85zmXyTMhp6A6Kupv6h3H6v/A9A==",
+      "dependencies": {
+        "@polkadot/api": "^9.6.2",
+        "@polkadot/rpc-provider": "^9.6.2",
+        "@polkadot/types": "^9.6.2"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.9.5",
@@ -5647,6 +5653,11 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz",
+      "integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA=="
+    },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -8027,9 +8038,14 @@
       }
     },
     "@frequency-chain/api-augment": {
-      "version": "0.9.29-rc1",
-      "resolved": "https://registry.npmjs.org/@frequency-chain/api-augment/-/api-augment-0.9.29-rc1.tgz",
-      "integrity": "sha512-RvXrkt6uqNCBfgmlL5qbAS1P/7lrQ3oJZmcd6KZF8bxSGEUYDqF2k2e2QPfpzrMxugkNSfCa73TbGVF0lEvhsA=="
+      "version": "0.9.29-2",
+      "resolved": "https://registry.npmjs.org/@frequency-chain/api-augment/-/api-augment-0.9.29-2.tgz",
+      "integrity": "sha512-SqHzOAkIfdTZxiPN5jYB1LJJi7X1K1XrTN/hCAur0Yce2I2+lfjFOdCLFbw85zmXyTMhp6A6Kupv6h3H6v/A9A==",
+      "requires": {
+        "@polkadot/api": "^9.6.2",
+        "@polkadot/rpc-provider": "^9.6.2",
+        "@polkadot/types": "^9.6.2"
+      }
     },
     "@humanwhocodes/config-array": {
       "version": "0.9.5",
@@ -11742,6 +11758,11 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
+    },
+    "json-stringify-pretty-compact": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz",
+      "integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA=="
     },
     "json-stringify-safe": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/LibertyDSNP/schemas#readme",
   "dependencies": {
-    "@frequency-chain/api-augment": "^0.9.29-2",
+    "@frequency-chain/api-augment": "0.9.29-2",
     "@polkadot/api": "^9.10.2",
     "@polkadot/extension-dapp": "^0.44.6",
     "@polkadot/types": "^9.10.2",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "test": "jest",
     "build": "tsc",
     "deploy": "ts-node index.ts",
+    "read": "ts-node read.ts",
     "clean": "rm -Rf dist",
     "format": "tsc --noEmit --pretty && eslint --fix \"**/*.ts\"",
     "lint": "tsc --noEmit --pretty && eslint \"**/*.ts\""
@@ -26,6 +27,7 @@
     "@polkadot/extension-dapp": "^0.44.6",
     "@polkadot/types": "^9.10.2",
     "jest-environment-jsdom": "^29.0.3",
+    "json-stringify-pretty-compact": "^3.0.0",
     "ts-node": "^10.8.1",
     "typescript": "^4.7.4"
   },

--- a/read.ts
+++ b/read.ts
@@ -1,0 +1,66 @@
+import "@frequency-chain/api-augment";
+import { getEndpoint, getFrequencyAPI } from "./services/connect";
+
+import stringify from "json-stringify-pretty-compact";
+
+import broadcast from "./dsnp/broadcast";
+import graphChange from "./dsnp/graphChange";
+import profile from "./dsnp/profile";
+import reaction from "./dsnp/reaction";
+import reply from "./dsnp/reply";
+import tombstone from "./dsnp/tombstone";
+import update from "./dsnp/update";
+
+const nameAndSchema = [
+    ["dsnp.broadcast", JSON.stringify(broadcast)],
+    ["dsnp.profile", JSON.stringify(profile)],
+    ["dsnp.reaction", JSON.stringify(reaction)],
+    ["dsnp.reply", JSON.stringify(reply)],
+    ["dsnp.tombstone", JSON.stringify(tombstone)],
+    ["dsnp.update", JSON.stringify(update)],
+    ["dsnp.graphChange", JSON.stringify(graphChange)],
+];
+
+const read = async () => {
+    const api = await getFrequencyAPI();
+
+    const { specName, specVersion } = await api.runtimeVersion;
+    const clientVersion = await api.rpc.system.version();
+    const endpointUrl = getEndpoint();
+
+    const latestBlockNumber = await api.query.system.number();
+
+    const connectionInfo = { endpointUrl, clientVersion, specName, specVersion, latestBlockNumber };
+    console.log("\n## Connection Information");
+    console.table(Object.entries(connectionInfo).map(([key, value]) => ({ key, value: value.toString() })));
+
+    console.log("\n## Schema Information");
+    const maxSchemaId = await (await api.query.schemas.currentSchemaIdentifierMaximum()).toNumber();
+    console.log(`There are ${maxSchemaId} schemas on the connected chain.`);
+
+    for (let i = 1; i <= maxSchemaId; i++) {
+        const schemaResult = await (await api.rpc.schemas.getBySchemaId(i)).unwrap();
+        const jsonSchema = Buffer.from(schemaResult.model).toString("utf8");
+        const modelParsed = JSON.parse(jsonSchema);
+        const { schema_id, model_type, payload_location } = schemaResult;
+
+        // Check for matches
+        const matchesDSNPSchemas = nameAndSchema.reduce((arr, [n, s]) => {
+            if (s === jsonSchema) arr.push(n);
+            return arr;
+        }, [])
+
+        console.log(`\n## Schema Id ${schema_id}`);
+        console.table(Object.entries({
+            schema_id, model_type, payload_location, matchesDSNPSchemas
+        }).map(([key, value]) => ({ key, value: value.toString() })));
+        console.log("\n## Schema Model");
+        console.log(stringify(modelParsed));
+    }
+}
+
+export const main = async () => {
+    await read();
+};
+
+main().catch(console.error).finally(process.exit);

--- a/services/connect.ts
+++ b/services/connect.ts
@@ -5,13 +5,8 @@ import { KeyringPair } from "@polkadot/keyring/types";
 
 // DEPLOY_SCHEMA_ENDPOINT_URL (environment variable)
 // The value is a URL for the RPC endpoint.  e.g. ws://localhost:9944
-export async function getFrequencyAPI(): Promise<ApiPromise> {
-  let DEPLOY_SCHEMA_ENDPOINT_URL = process.env.DEPLOY_SCHEMA_ENDPOINT_URL;
-  if (DEPLOY_SCHEMA_ENDPOINT_URL === undefined) {
-    // One would think that localhost would also work here but it doesn't consistently.
-    DEPLOY_SCHEMA_ENDPOINT_URL = "ws://127.0.0.1:9944";
-  }
-  const DefaultWsProvider = new WsProvider(DEPLOY_SCHEMA_ENDPOINT_URL);
+export async function getFrequencyAPI() {
+  const DefaultWsProvider = new WsProvider(getEndpoint());
 
   // The "options" parameter pulls in the Frequency API extrinsics
   const api = await ApiPromise.create({
@@ -20,6 +15,15 @@ export async function getFrequencyAPI(): Promise<ApiPromise> {
   });
   await api.isReady;
   return api;
+}
+
+export function getEndpoint() {
+  let DEPLOY_SCHEMA_ENDPOINT_URL = process.env.DEPLOY_SCHEMA_ENDPOINT_URL;
+  if (DEPLOY_SCHEMA_ENDPOINT_URL === undefined) {
+    // One would think that localhost would also work here but it doesn't consistently.
+    DEPLOY_SCHEMA_ENDPOINT_URL = "ws://127.0.0.1:9944";
+  }
+  return DEPLOY_SCHEMA_ENDPOINT_URL;
 }
 
 // DEPLOY_SCHEMA_ACCOUNT_URI (environment variable)


### PR DESCRIPTION
Problem
=======
It was difficult to determine what was deployed to a particular chain.

Solution
========
Added a read command that reads all the schemas and then prints them out while attempting to identify dsnp schema matches.

Change summary:
---------------
* Updated to api-augment `0.9.29-2`
* Added read command
* Added README documentation about read command
