### PR TITLE
Spike/add deploy schemas to instant seal node

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+**/*.txt
+**/*.md
+# dotfiles in the repo root
+/.*
+**/node_modules/
+Dockerfile
+**/*.dockerfile

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,39 @@
+name: Release Instant Seal Node With Deployed Schemas Docker Image
+on:
+  push:
+    tags: [ docker/* ]
+
+jobs:
+  docker-release:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Get the tag name
+        run: |
+          echo ${GITHUB_REF##*/}
+          echo "TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
+
+      - name: Build and push dsnp/instant-seal-node-with-deployed-schemas
+        id: docker_build_instant_seal_node_with_deployed_schemas
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          file: Dockerfile
+          tags: |
+            dsnp/instant-seal-node-with-deployed-schemas:${{ env.TAG }}
+            dsnp/instant-seal-node-with-deployed-schemas:latest
+
+
+      - name: Image digests
+        run: |
+          echo dsnp/instant-seal-node-with-deployed-schemas ${{ steps.docker_build_instant_seal_node_with_deployed_schemas.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,15 @@ USER root
 LABEL maintainer="Frequency"
 LABEL description="Frequency collator node in instant seal mode with schemas deployed"
 
-RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificates
+RUN apt-get update \
+    && apt-get install -y ca-certificates \
+    && update-ca-certificates
 
 # Install node-js to base image
-RUN apt-get update && apt-get install -y curl gnupg
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash
-RUN apt-get update && apt-get install -y nodejs
+RUN apt-get update && apt-get install -y curl gnupg \
+        && curl -sL https://deb.nodesource.com/setup_16.x | bash \
+        && apt-get update && apt-get install -y nodejs \
+        && rm -rf /var/lib/apt/lists/*
 
 # Switch back to frequency user
 
@@ -28,6 +31,9 @@ RUN chmod +x ./frequency/deploy_schemas_to_node.sh
 # Copy over schemas repo
 RUN mkdir frequency/schemas
 COPY --chown=frequency ./ ./frequency/schemas
+RUN cd frequency/schemas \
+    && npm install \
+    && cd $WORKSPACE
 
 # Install tini to use as new entrypoint
 ENV TINI_VERSION v0.19.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# Docker image for running Frequency parachain node container (with collating)
+# locally in instant seal mode then deploying schemas to that node.
+
+#This pulls the latest instant-seal-node image
+FROM frequencychain/instant-seal-node as frequency-image
+
+#Switch to root to install node on image
+USER root
+
+LABEL maintainer="Frequency"
+LABEL description="Frequency collator node in instant seal mode with schemas deployed"
+
+RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificates
+
+# Install node-js to base image
+RUN apt-get update && apt-get install -y curl gnupg
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash
+RUN apt-get update && apt-get install -y nodejs
+
+# Switch back to frequency user
+
+USER frequency
+
+# Copy over deploy_schemas script to base image
+COPY --chown=frequency scripts/deploy_schemas_to_node.sh ./frequency/
+RUN chmod +x ./frequency/deploy_schemas_to_node.sh
+
+# Copy over schemas repo
+RUN mkdir frequency/schemas
+COPY --chown=frequency ./ ./frequency/schemas
+
+# Install tini to use as new entrypoint
+ENV TINI_VERSION v0.19.0
+ADD --chown=frequency https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+
+# 9933 P2P port
+# 9944 for RPC call
+# 30333 for Websocket
+EXPOSE 9933 9944 30333
+
+VOLUME ["/data"]
+
+ENTRYPOINT ["/tini", "--"]
+
+# Params which can be overriden from CLI
+CMD ["/bin/bash", "frequency/deploy_schemas_to_node.sh"]

--- a/README.md
+++ b/README.md
@@ -94,3 +94,22 @@ There are 8 schemas on the connected chain.
 ]
 ...
 ```
+
+# dsnp/instant-seal-node-with-deployed-schemas
+## Pushing Docker Image
+This repo includes a docker image to push an instant-seal-node with the schemas deployed on top of it to docker hub under dsnp/instant-seal-node-with-deployed-schemas.
+To match with the frequency version, a new tag should be pushed to update the docker version of this image each time frequency releases a new version.
+The following steps explain how to properly do a release for this.
+1. Go to the [frequency repo](https://github.com/LibertyDSNP/frequency/releases) to see what the latest release version is.
+2. In this repo, check that main is properly passing its tests and building [here](https://github.com/LibertyDSNP/schemas/actions)
+3. Go to main: `git checkout main && git pull --rebase`
+4. Make sure to pull all latest tags as well: `git pull --tags`
+5. Tag the build to match the frequency version but appended with "docker/": `git tag docker/{insert version number}`. For example, if the version number is v1.0.0, then the tag should be `docker/v1.0.0`
+Push the tag up: `git push --tags`
+6. Monitor the [build](https://github.com/LibertyDSNP/schemas/actions)
+7. When that finishes successfully, check [docker hub](https://hub.docker.com/r/dsnp/instant-seal-node-with-deployed-schemas/tags) to verify that the image was pushed up
+
+## To run locally
+For any local testing do the following:
+1. docker pull dsnp/instant-seal-node-with-deployed-schemas:latest
+2. docker run docker run --rm -p 9944:9944 -p 9933:9933 -p 30333:30333 dsnp/instant-seal-node-with-deployed-schemas:latest

--- a/scripts/deploy_schemas_to_node.sh
+++ b/scripts/deploy_schemas_to_node.sh
@@ -10,8 +10,6 @@ whoami
 /frequency/frequency --dev \
     -lruntime=debug \
     --instant-sealing \
-    --wasm-execution=compiled \
-    --execution=wasm \
     --no-telemetry \
     --no-prometheus \
     --port=30333 \
@@ -25,6 +23,6 @@ whoami
     &
 
 cd frequency/schemas
-npm install && npm run deploy
+npm run deploy
 
 fg %1

--- a/scripts/deploy_schemas_to_node.sh
+++ b/scripts/deploy_schemas_to_node.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -m
+
+#Useful for future debugging
+npm --version
+ldd --version
+whoami
+
+/frequency/frequency --dev \
+    -lruntime=debug \
+    --instant-sealing \
+    --wasm-execution=compiled \
+    --execution=wasm \
+    --no-telemetry \
+    --no-prometheus \
+    --port=30333 \
+    --rpc-port=9933 \
+    --ws-port=9944 \
+    --rpc-external \
+    --rpc-cors=all \
+    --ws-external \
+    --rpc-methods=Unsafe \
+    --tmp \
+    &
+
+cd frequency/schemas
+npm install && npm run deploy
+
+fg %1


### PR DESCRIPTION
Problem
=======
Testing with frequency instant seal node can require deploying schemas to the node, which is an added layer of complexity when writing end to end tests

Closes: [184003669](https://www.pivotaltracker.com/story/show/184003669)

Solution
========
Created a dockerfile in this repo to take latest frequency instant seal node image and deploy schemas on top of it. Additionally added a github actions workflow to update dockerhub with a new version and latest each time we push a new tag. This will need to be manually done when frequency updates versions to match with it.


Change summary:
---------------
Adding a docker image to deploy schemas to a frequency instant seal node, which will aid with testing in test containers as well as improve general quality of life when developing on frequency.

Steps to Verify:
----------------
To run locally
1. Make sure terminal is at schemas root directory
2. To build on intel mac (on a m1 chip switch "amd64" with "arm64"), run this (and sub with whatever name you want the image to be: docker buildx build --platform=linux/amd64 -f docker/instant-seal-node-with-deployed-schemas.dockerfile -t .
3. To run image after building on intel mac, run this (and sub image name with whatever you tagged the name in previous command): docker run --rm -dp 9944:9944 -p 9933:9933 -p 30333:30333 
