### PR TITLE
Modify deploy_schemas script to run new frequency instant-seal docker image

### DIFF
--- a/scripts/deploy_schemas_to_node.sh
+++ b/scripts/deploy_schemas_to_node.sh
@@ -19,7 +19,7 @@ whoami
     --rpc-cors=all \
     --ws-external \
     --rpc-methods=Unsafe \
-    --tmp \
+    --base-path=/data \
     &
 
 cd frequency/schemas


### PR DESCRIPTION
Frequency is changing their instant seal node docker image to allow either instant sealing or manual sealing and some parameters changed to run the binary. This PR is to update the deploy_schemas_to_node script to match those changes

Note: need to change the frequencychain/instant-seal-node version to 1.2.1 when it's released
