### PR TITLE
Update for Frequency 1.4.0 and DSNP 1.2.0

### DIFF
--- a/deploy.ts
+++ b/deploy.ts
@@ -1,31 +1,7 @@
-import broadcast from "./dsnp/broadcast";
-import graphChange from "./dsnp/graphChange";
-import profile from "./dsnp/profile";
-import reaction from "./dsnp/reaction";
-import reply from "./dsnp/reply";
-import tombstone from "./dsnp/tombstone";
-import publicKey from "./dsnp/publicKey";
-import userPublicGraph from "./dsnp/userPublicGraph";
-import userPrivateGraph from "./dsnp/userPrivateGraph";
-import { ParquetModel } from "./types/frequency";
-import update from "./dsnp/update";
 import type { EventRecord } from "@polkadot/types/interfaces/system";
 
 import { getFrequencyAPI, getSignerAccountKeys } from "./services/connect";
-
-// Map schema names (string) to schema object
-const nameToSchema = new Map<string, ParquetModel | object>([
-  ["broadcast", broadcast],
-  ["profile", profile],
-  ["reaction", reaction],
-  ["reply", reply],
-  ["tombstone", tombstone],
-  ["update", update],
-  ["graphChange", graphChange],
-  ["publicKey", publicKey],
-  ["userPublicGraph", userPublicGraph],
-  ["userPrivateGraph", userPrivateGraph],
-]);
+import { dsnpSchemas } from "./dsnp";
 
 export const deploy = async () => {
   console.log("Deploy of Schemas Starting...");
@@ -36,11 +12,11 @@ export const deploy = async () => {
   let schema_names: string[];
 
   if (args.length == 0) {
-    schema_names = [...nameToSchema.keys()];
+    schema_names = [...dsnpSchemas.keys()];
   } else if (args.length == 1) {
     // Does schema with name exist?
     const schemaName = args[0];
-    const sc = nameToSchema.get(schemaName);
+    const sc = dsnpSchemas.get(schemaName);
     if (sc == undefined) {
       console.error("ERROR: No specified schema with name.");
       process.exit(1);
@@ -75,55 +51,30 @@ const createSchemas = async (schema_names: string[]) => {
     console.log("Attempting to create " + schemaName + " schema.");
 
     // Get the schema from the name
-    const schema = nameToSchema.get(schemaName);
+    const schemaDeploy = dsnpSchemas.get(schemaName);
+    if (!schemaDeploy) throw `Unknown Schema name: ${schemaName}`;
     // Create JSON from the schema object
-    const json = JSON.stringify(schema);
+    const json = JSON.stringify(schemaDeploy?.model);
     // Remove whitespace in the JSON
     const json_no_ws = JSON.stringify(JSON.parse(json));
 
-    let promise;
-
-    // The default model type/payload type is Parquet/IPFS
-    // unless it is a graphChange schema which is AvroBinary/OnChain.
-    if (schemaName === "graphChange") {
-      // Avro
-      promise = new Promise<void>((resolve, reject) => {
-        api.tx.schemas
-          .createSchema(json_no_ws, "AvroBinary", "OnChain")
-          .signAndSend(signerAccountKeys, { nonce: nonce++ }, ({ status, events, dispatchError }) => {
-            if (dispatchError) {
-              console.log("ERROR: " + dispatchError.toHuman());
-              reject();
-            } else if (status.isInBlock || status.isFinalized) {
-              const evt = eventWithSectionAndMethod(events, "schemas", "SchemaCreated");
-              if (evt) {
-                const val = evt?.data[1];
-                console.log("SUCCESS: " + schemaName + " schema created with id of " + val);
-              }
-              resolve();
+    const promise = new Promise<void>((resolve, reject) => {
+      api.tx.schemas
+        .createSchema(json_no_ws, schemaDeploy.modelType, schemaDeploy.payloadLocation)
+        .signAndSend(signerAccountKeys, { nonce: nonce++ }, ({ status, events, dispatchError }) => {
+          if (dispatchError) {
+            console.log("ERROR: " + dispatchError.toHuman());
+            reject();
+          } else if (status.isInBlock || status.isFinalized) {
+            const evt = eventWithSectionAndMethod(events, "schemas", "SchemaCreated");
+            if (evt) {
+              const val = evt?.data[1];
+              console.log("SUCCESS: " + schemaName + " schema created with id of " + val);
             }
-          });
-      });
-    } else {
-      // Parquet
-      promise = new Promise<void>((resolve, reject) => {
-        api.tx.schemas
-          .createSchema(json_no_ws, "Parquet", "IPFS")
-          .signAndSend(signerAccountKeys, { nonce: nonce++ }, ({ status, events, dispatchError }) => {
-            if (dispatchError) {
-              console.log("ERROR: " + dispatchError.toHuman());
-              reject();
-            } else if (status.isInBlock || status.isFinalized) {
-              const evt = eventWithSectionAndMethod(events, "schemas", "SchemaCreated");
-              if (evt) {
-                const val = evt?.data[1];
-                console.log("SUCCESS: " + schemaName + " schema created with id of " + val);
-              }
-              resolve();
-            }
-          });
-      });
-    }
+            resolve();
+          }
+        });
+    });
     promises.push(promise);
   }
   return Promise.all(promises);

--- a/dsnp/index.ts
+++ b/dsnp/index.ts
@@ -1,0 +1,116 @@
+import broadcast from "./broadcast";
+// Deprecated
+// import graphChange from "./dsnp/graphChange";
+import profile from "./profile";
+import reaction from "./reaction";
+import reply from "./reply";
+import tombstone from "./tombstone";
+import publicKey from "./publicKey";
+import userPublicFollows from "./userPublicFollows";
+import userPrivateFollows from "./userPrivateFollows";
+import userPrivateConnections from "./userPrivateConnections";
+import { ParquetModel } from "../types/frequency";
+import update from "./update";
+
+type PayloadLocation = "IPFS" | "OnChain" | "Itemized" | "Paginated";
+type ModelType = "AvroBinary" | "Parquet";
+
+export type Deploy = {
+  model: ParquetModel | object;
+  modelType: ModelType;
+  payloadLocation: PayloadLocation;
+};
+
+// Map schema names (string) to deploy object
+export const dsnpSchemas = new Map<string, Deploy>([
+  [
+    "broadcast",
+    {
+      model: broadcast,
+      modelType: "Parquet",
+      payloadLocation: "IPFS",
+    },
+  ],
+  [
+    "profile",
+    {
+      model: profile,
+      modelType: "Parquet",
+      payloadLocation: "IPFS",
+    },
+  ],
+  [
+    "reaction",
+    {
+      model: reaction,
+      modelType: "Parquet",
+      payloadLocation: "IPFS",
+    },
+  ],
+  [
+    "reply",
+    {
+      model: reply,
+      modelType: "Parquet",
+      payloadLocation: "IPFS",
+    },
+  ],
+  [
+    "tombstone",
+    {
+      model: tombstone,
+      modelType: "Parquet",
+      payloadLocation: "IPFS",
+    },
+  ],
+  [
+    "update",
+    {
+      model: update,
+      modelType: "Parquet",
+      payloadLocation: "IPFS",
+    },
+  ],
+  // Deprecated
+  // ["graphChange", {
+  //   model: graphChange,
+  //   modelType: "Parquet",
+  //   payloadLocation: "IPFS"
+  // }],
+  [
+    "publicKey",
+    {
+      model: publicKey,
+      modelType: "AvroBinary",
+      payloadLocation: "Itemized",
+    },
+  ],
+  [
+    "userPublicFollows",
+    {
+      model: userPublicFollows,
+      modelType: "AvroBinary",
+      payloadLocation: "Paginated",
+    },
+  ],
+  [
+    "userPrivateFollows",
+    {
+      model: userPrivateFollows,
+      modelType: "AvroBinary",
+      payloadLocation: "Paginated",
+    },
+  ],
+  [
+    "userPrivateConnections",
+    {
+      model: userPrivateConnections,
+      modelType: "AvroBinary",
+      payloadLocation: "Paginated",
+    },
+  ],
+]);
+
+export const getSchema = (name: string): Deploy | null => {
+  return dsnpSchemas.get(name) || null;
+};

--- a/dsnp/publicKey.ts
+++ b/dsnp/publicKey.ts
@@ -18,10 +18,5 @@ export default {
       type: "long",
       doc: "User-Assigned Key Identifier",
     },
-    {
-      name: "revokedAsOf",
-      type: "long",
-      doc: "Unix epoch seconds",
-    },
   ],
 };

--- a/dsnp/userPrivateConnections.spec.ts
+++ b/dsnp/userPrivateConnections.spec.ts
@@ -1,17 +1,17 @@
-import privateGraphSchema from "./userPrivateGraph";
+import privateConnectionsSchema from "./userPrivateConnections";
 import avro from "avro-js";
 
-describe("Private Graph Schema", () => {
+describe("Private Connections Schema", () => {
   it("Is Avro", () => {
-    const parsed = avro.parse(privateGraphSchema);
+    const parsed = avro.parse(privateConnectionsSchema);
     expect(parsed).toBeDefined();
   });
 
   it("can work with the inside type", () => {
     // Parse the inside and outside types.
     // The inside type must be self contained.
-    const outsideType = avro.parse(privateGraphSchema);
-    const insideType = avro.parse(privateGraphSchema.types[0]);
+    const outsideType = avro.parse(privateConnectionsSchema);
+    const insideType = avro.parse(privateConnectionsSchema.types[0]);
 
     // Generate a random inside type
     const inside = insideType.random();

--- a/dsnp/userPrivateConnections.ts
+++ b/dsnp/userPrivateConnections.ts
@@ -1,0 +1,54 @@
+// Paginated Chunk with PRIds
+export default {
+  type: "record",
+  name: "UserPrivateConnectionsChunk",
+  namespace: "org.dsnp",
+  fields: [
+    {
+      name: "keyId",
+      type: "long",
+      doc: "User-Assigned Key Identifier",
+    },
+    {
+      name: "pridList",
+      type: {
+        type: "array",
+        items: {
+          name: "prid",
+          type: "fixed",
+          size: 8,
+          doc: "Pseudonymous Relationship Identifier",
+        },
+      },
+    },
+    {
+      doc: "lib_sodium sealed box",
+      name: "encryptedCompressedPrivateGraph",
+      type: "bytes",
+    },
+  ],
+  types: [
+    // This is the inside type of the decrypted and decompressed data
+    {
+      type: "array",
+      name: "PrivateGraph",
+      namespace: "org.dsnp",
+      items: {
+        type: "record",
+        name: "GraphEdge",
+        fields: [
+          {
+            name: "userId",
+            type: "long",
+            doc: "DSNP User Id of object of relationship",
+          },
+          {
+            name: "since",
+            type: "long",
+            doc: "Unix epoch in seconds when this relationship was originally established rounded to the nearest 1000",
+          },
+        ],
+      },
+    },
+  ],
+};

--- a/dsnp/userPrivateFollows.spec.ts
+++ b/dsnp/userPrivateFollows.spec.ts
@@ -1,30 +1,36 @@
-import publicGraphSchema from "./userPublicGraph";
+import privateFollowsSchema from "./userPrivateFollows";
 import avro from "avro-js";
 
-describe("Public Graph Schema", () => {
+describe("Private Follows Schema", () => {
   it("Is Avro", () => {
-    const parsed = avro.parse(publicGraphSchema);
+    const parsed = avro.parse(privateFollowsSchema);
     expect(parsed).toBeDefined();
   });
 
   it("can work with the inside type", () => {
     // Parse the inside and outside types.
     // The inside type must be self contained.
-    const outsideType = avro.parse(publicGraphSchema);
-    const insideType = avro.parse(publicGraphSchema.types[0]);
+    const outsideType = avro.parse(privateFollowsSchema);
+    const insideType = avro.parse(privateFollowsSchema.types[0]);
 
     // Generate a random inside type
     const inside = insideType.random();
     const insideBuffer = insideType.toBuffer(inside);
 
+    const keyIdType = avro.parse({
+      name: "identifier",
+      type: "long",
+    });
+
     // Generate the outside and buffer
     const outsideBuffer = outsideType.toBuffer({
-      compressedPublicGraph: insideBuffer,
+      keyId: keyIdType.random(),
+      encryptedCompressedPrivateGraph: insideBuffer,
     });
 
     // Start from just the outsideBuffer and type
     const outsideParsed = outsideType.fromBuffer(outsideBuffer);
-    const insideParsed = insideType.fromBuffer(outsideParsed.compressedPublicGraph);
+    const insideParsed = insideType.fromBuffer(outsideParsed.encryptedCompressedPrivateGraph);
 
     // Check the inside parsed data is the same as the original.
     expect(insideParsed).toEqual(inside);

--- a/dsnp/userPrivateFollows.ts
+++ b/dsnp/userPrivateFollows.ts
@@ -1,19 +1,25 @@
-// Paginated Chunk of compressed data with a type defined for the data post decompression
+// Paginated Chunk with PRIds
 export default {
   type: "record",
-  name: "UserPublicGraphChunk",
+  name: "UserPrivateFollowsChunk",
   namespace: "org.dsnp",
   fields: [
     {
-      name: "compressedPublicGraph",
+      name: "keyId",
+      type: "long",
+      doc: "User-Assigned Key Identifier",
+    },
+    {
+      doc: "lib_sodium sealed box",
+      name: "encryptedCompressedPrivateGraph",
       type: "bytes",
     },
   ],
   types: [
-    // This is the inside type of the decompressed data
+    // This is the inside type of the decrypted and decompressed data
     {
       type: "array",
-      name: "PublicGraph",
+      name: "PrivateGraph",
       namespace: "org.dsnp",
       items: {
         type: "record",

--- a/dsnp/userPrivateFollows.ts
+++ b/dsnp/userPrivateFollows.ts
@@ -1,4 +1,4 @@
-// Paginated Chunk with PRIds
+// Paginated Chunks
 export default {
   type: "record",
   name: "UserPrivateFollowsChunk",

--- a/dsnp/userPublicFollows.spec.ts
+++ b/dsnp/userPublicFollows.spec.ts
@@ -1,0 +1,32 @@
+import publicFollowsSchema from "./userPublicFollows";
+import avro from "avro-js";
+
+describe("Public Follows Schema", () => {
+  it("Is Avro", () => {
+    const parsed = avro.parse(publicFollowsSchema);
+    expect(parsed).toBeDefined();
+  });
+
+  it("can work with the inside type", () => {
+    // Parse the inside and outside types.
+    // The inside type must be self contained.
+    const outsideType = avro.parse(publicFollowsSchema);
+    const insideType = avro.parse(publicFollowsSchema.types[0]);
+
+    // Generate a random inside type
+    const inside = insideType.random();
+    const insideBuffer = insideType.toBuffer(inside);
+
+    // Generate the outside and buffer
+    const outsideBuffer = outsideType.toBuffer({
+      compressedPublicGraph: insideBuffer,
+    });
+
+    // Start from just the outsideBuffer and type
+    const outsideParsed = outsideType.fromBuffer(outsideBuffer);
+    const insideParsed = insideType.fromBuffer(outsideParsed.compressedPublicGraph);
+
+    // Check the inside parsed data is the same as the original.
+    expect(insideParsed).toEqual(inside);
+  });
+});

--- a/dsnp/userPublicFollows.ts
+++ b/dsnp/userPublicFollows.ts
@@ -1,37 +1,19 @@
-// Paginated Chunk with PRIds
+// Paginated Chunk of compressed data with a type defined for the data post decompression
 export default {
   type: "record",
-  name: "UserPrivateGraphChunk",
+  name: "UserPublicFollowsChunk",
   namespace: "org.dsnp",
   fields: [
     {
-      name: "keyId",
-      type: "long",
-      doc: "User-Assigned Key Identifier",
-    },
-    {
-      name: "pridList",
-      type: {
-        type: "array",
-        items: {
-          name: "prid",
-          type: "fixed",
-          size: 8,
-          doc: "Pseudonymous Relationship Identifier",
-        },
-      },
-    },
-    {
-      doc: "lib_sodium sealed box",
-      name: "encryptedCompressedPrivateGraph",
+      name: "compressedPublicGraph",
       type: "bytes",
     },
   ],
   types: [
-    // This is the inside type of the decrypted and decompressed data
+    // This is the inside type of the decompressed data
     {
       type: "array",
-      name: "PrivateGraph",
+      name: "PublicGraph",
       namespace: "org.dsnp",
       items: {
         type: "record",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@frequency-chain/api-augment": "1.4.0-rc3",
+        "@frequency-chain/api-augment": "1.5.1",
         "@polkadot/api": "^9.14.1",
         "@polkadot/extension-dapp": "^0.44.6",
         "@polkadot/types": "^9.14.1",
@@ -696,9 +696,9 @@
       }
     },
     "node_modules/@frequency-chain/api-augment": {
-      "version": "1.4.0-rc3",
-      "resolved": "https://registry.npmjs.org/@frequency-chain/api-augment/-/api-augment-1.4.0-rc3.tgz",
-      "integrity": "sha512-R2JJZTh6/T34E7NZiLtXxd0ErXfpaZtRtyUN6YG5CYFkfpvYeRav6t+/vUfkWcta7SLgHwa1KfII7VpBTzNeMA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@frequency-chain/api-augment/-/api-augment-1.5.1.tgz",
+      "integrity": "sha512-H2T4Nf/ZRxGcaAfweV9yr8FyhVZcUpyQG9chiFzd0i2l84cBB5+x6mcKYZM4tdsgiqtVqqjAJ9BkH494UblIvQ==",
       "dependencies": {
         "@polkadot/api": "^9.14.2",
         "@polkadot/rpc-provider": "^9.14.2",
@@ -8238,9 +8238,9 @@
       }
     },
     "@frequency-chain/api-augment": {
-      "version": "1.4.0-rc3",
-      "resolved": "https://registry.npmjs.org/@frequency-chain/api-augment/-/api-augment-1.4.0-rc3.tgz",
-      "integrity": "sha512-R2JJZTh6/T34E7NZiLtXxd0ErXfpaZtRtyUN6YG5CYFkfpvYeRav6t+/vUfkWcta7SLgHwa1KfII7VpBTzNeMA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@frequency-chain/api-augment/-/api-augment-1.5.1.tgz",
+      "integrity": "sha512-H2T4Nf/ZRxGcaAfweV9yr8FyhVZcUpyQG9chiFzd0i2l84cBB5+x6mcKYZM4tdsgiqtVqqjAJ9BkH494UblIvQ==",
       "requires": {
         "@polkadot/api": "^9.14.2",
         "@polkadot/rpc-provider": "^9.14.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@frequency-chain/api-augment": "1.2.0",
+        "@frequency-chain/api-augment": "1.4.0-rc3",
         "@polkadot/api": "^9.14.1",
         "@polkadot/extension-dapp": "^0.44.6",
         "@polkadot/types": "^9.14.1",
@@ -696,13 +696,13 @@
       }
     },
     "node_modules/@frequency-chain/api-augment": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@frequency-chain/api-augment/-/api-augment-1.2.0.tgz",
-      "integrity": "sha512-tTpygDmUGbQ4AASoWpXHA/n47tavGjlawr+XPM7zqg7D10w6ECtJBOXxoXKN1cw5R9YfStwVeGRgIF+EBEw9sg==",
+      "version": "1.4.0-rc3",
+      "resolved": "https://registry.npmjs.org/@frequency-chain/api-augment/-/api-augment-1.4.0-rc3.tgz",
+      "integrity": "sha512-R2JJZTh6/T34E7NZiLtXxd0ErXfpaZtRtyUN6YG5CYFkfpvYeRav6t+/vUfkWcta7SLgHwa1KfII7VpBTzNeMA==",
       "dependencies": {
-        "@polkadot/api": "^9.13.2",
-        "@polkadot/rpc-provider": "^9.13.2",
-        "@polkadot/types": "^9.13.2"
+        "@polkadot/api": "^9.14.2",
+        "@polkadot/rpc-provider": "^9.14.2",
+        "@polkadot/types": "^9.14.2"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1161,25 +1161,25 @@
       }
     },
     "node_modules/@polkadot/api": {
-      "version": "9.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-9.14.1.tgz",
-      "integrity": "sha512-7fQxH6cPOUTH6psEDkaskkgfD+R0CUL0vBYj0BD8e4yxWMsdz4lbuyBl8A6DOVjMD40ZU9HTL3GqQzud5dEdMw==",
+      "version": "9.14.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-9.14.2.tgz",
+      "integrity": "sha512-R3eYFj2JgY1zRb+OCYQxNlJXCs2FA+AU4uIEiVcXnVLmR3M55tkRNEwYAZmiFxx0pQmegGgPMc33q7TWGdw24A==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/api-augment": "9.14.1",
-        "@polkadot/api-base": "9.14.1",
-        "@polkadot/api-derive": "9.14.1",
-        "@polkadot/keyring": "^10.4.1",
-        "@polkadot/rpc-augment": "9.14.1",
-        "@polkadot/rpc-core": "9.14.1",
-        "@polkadot/rpc-provider": "9.14.1",
-        "@polkadot/types": "9.14.1",
-        "@polkadot/types-augment": "9.14.1",
-        "@polkadot/types-codec": "9.14.1",
-        "@polkadot/types-create": "9.14.1",
-        "@polkadot/types-known": "9.14.1",
-        "@polkadot/util": "^10.4.1",
-        "@polkadot/util-crypto": "^10.4.1",
+        "@polkadot/api-augment": "9.14.2",
+        "@polkadot/api-base": "9.14.2",
+        "@polkadot/api-derive": "9.14.2",
+        "@polkadot/keyring": "^10.4.2",
+        "@polkadot/rpc-augment": "9.14.2",
+        "@polkadot/rpc-core": "9.14.2",
+        "@polkadot/rpc-provider": "9.14.2",
+        "@polkadot/types": "9.14.2",
+        "@polkadot/types-augment": "9.14.2",
+        "@polkadot/types-codec": "9.14.2",
+        "@polkadot/types-create": "9.14.2",
+        "@polkadot/types-known": "9.14.2",
+        "@polkadot/util": "^10.4.2",
+        "@polkadot/util-crypto": "^10.4.2",
         "eventemitter3": "^5.0.0",
         "rxjs": "^7.8.0"
       },
@@ -1188,31 +1188,31 @@
       }
     },
     "node_modules/@polkadot/api-augment": {
-      "version": "9.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-9.14.1.tgz",
-      "integrity": "sha512-wx9mrNTI3QmO3lfy34KN+TQUwEdgEZzDbZTH8Y+AiQx5hX34oAHTHcKbKoIEF9ENhXhmbNMiEERccH+0GC/1OQ==",
+      "version": "9.14.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-9.14.2.tgz",
+      "integrity": "sha512-19MmW8AHEcLkdcUIo3LLk0eCQgREWqNSxkUyOeWn7UiNMY1AhDOOwMStUBNCvrIDK6VL6GGc1sY7rkPCLMuKSw==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/api-base": "9.14.1",
-        "@polkadot/rpc-augment": "9.14.1",
-        "@polkadot/types": "9.14.1",
-        "@polkadot/types-augment": "9.14.1",
-        "@polkadot/types-codec": "9.14.1",
-        "@polkadot/util": "^10.4.1"
+        "@polkadot/api-base": "9.14.2",
+        "@polkadot/rpc-augment": "9.14.2",
+        "@polkadot/types": "9.14.2",
+        "@polkadot/types-augment": "9.14.2",
+        "@polkadot/types-codec": "9.14.2",
+        "@polkadot/util": "^10.4.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/api-base": {
-      "version": "9.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-9.14.1.tgz",
-      "integrity": "sha512-bhVZEexTq7qMaq5OoTxjJZgHRA8OPY050tn741JSD5qP9cnZ1xX1H2SElmw3yIlA5juA34V+1gwhxxa4tkDOwA==",
+      "version": "9.14.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-9.14.2.tgz",
+      "integrity": "sha512-ky9fmzG1Tnrjr/SBZ0aBB21l0TFr+CIyQenQczoUyVgiuxVaI/2Bp6R2SFrHhG28P+PW2/RcYhn2oIAR2Z2fZQ==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/rpc-core": "9.14.1",
-        "@polkadot/types": "9.14.1",
-        "@polkadot/util": "^10.4.1",
+        "@polkadot/rpc-core": "9.14.2",
+        "@polkadot/types": "9.14.2",
+        "@polkadot/util": "^10.4.2",
         "rxjs": "^7.8.0"
       },
       "engines": {
@@ -1220,19 +1220,19 @@
       }
     },
     "node_modules/@polkadot/api-derive": {
-      "version": "9.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-9.14.1.tgz",
-      "integrity": "sha512-urDXH+LHTJHEn5eAT4dOQAGFi3MGa2OnZo0lRYeIkIis9Bl7+Lhh2YKmoL5iFR1BBpmNSL82nlVNjfI2m7oiKA==",
+      "version": "9.14.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-9.14.2.tgz",
+      "integrity": "sha512-yw9OXucmeggmFqBTMgza0uZwhNjPxS7MaT7lSCUIRKckl1GejdV+qMhL3XFxPFeYzXwzFpdPG11zWf+qJlalqw==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/api": "9.14.1",
-        "@polkadot/api-augment": "9.14.1",
-        "@polkadot/api-base": "9.14.1",
-        "@polkadot/rpc-core": "9.14.1",
-        "@polkadot/types": "9.14.1",
-        "@polkadot/types-codec": "9.14.1",
-        "@polkadot/util": "^10.4.1",
-        "@polkadot/util-crypto": "^10.4.1",
+        "@polkadot/api": "9.14.2",
+        "@polkadot/api-augment": "9.14.2",
+        "@polkadot/api-base": "9.14.2",
+        "@polkadot/rpc-core": "9.14.2",
+        "@polkadot/types": "9.14.2",
+        "@polkadot/types-codec": "9.14.2",
+        "@polkadot/util": "^10.4.2",
+        "@polkadot/util-crypto": "^10.4.2",
         "rxjs": "^7.8.0"
       },
       "engines": {
@@ -1272,29 +1272,29 @@
       }
     },
     "node_modules/@polkadot/keyring": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-10.4.1.tgz",
-      "integrity": "sha512-urTl0ReOr1A1b2kSF6QnGlVc2IcJpDnTacxwA4kIVn45p4Kysi19ek7odSdLA5yNcDZSB+/4uITZQ6meClS71Q==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-10.4.2.tgz",
+      "integrity": "sha512-7iHhJuXaHrRTG6cJDbZE9G+c1ts1dujp0qbO4RfAPmT7YUvphHvAtCKueN9UKPz5+TYDL+rP/jDEaSKU8jl/qQ==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/util": "10.4.1",
-        "@polkadot/util-crypto": "10.4.1"
+        "@polkadot/util": "10.4.2",
+        "@polkadot/util-crypto": "10.4.2"
       },
       "engines": {
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "@polkadot/util": "10.4.1",
-        "@polkadot/util-crypto": "10.4.1"
+        "@polkadot/util": "10.4.2",
+        "@polkadot/util-crypto": "10.4.2"
       }
     },
     "node_modules/@polkadot/networks": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-10.4.1.tgz",
-      "integrity": "sha512-kmSy8iAnYKNWXZBv7bTfI10cSLJzOrFFEdngzohHMjDOG5FKoaX3Pix6MUkcWc2asX0hCyACtNTlcp+MBnS9eQ==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-10.4.2.tgz",
+      "integrity": "sha512-FAh/znrEvWBiA/LbcT5GXHsCFUl//y9KqxLghSr/CreAmAergiJNT0MVUezC7Y36nkATgmsr4ylFwIxhVtuuCw==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/util": "10.4.1",
+        "@polkadot/util": "10.4.2",
         "@substrate/ss58-registry": "^1.38.0"
       },
       "engines": {
@@ -1302,30 +1302,30 @@
       }
     },
     "node_modules/@polkadot/rpc-augment": {
-      "version": "9.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-9.14.1.tgz",
-      "integrity": "sha512-F7pP7YzSrQKDE6LFpfcGIsr1/XLLFwwuIeqyT1nBP9KN9FzykvrDdWaxM0TJqNEf27EFkd3HXeWbGISTPLje0A==",
+      "version": "9.14.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-9.14.2.tgz",
+      "integrity": "sha512-mOubRm3qbKZTbP9H01XRrfTk7k5it9WyzaWAg72DJBQBYdgPUUkGSgpPD/Srkk5/5GAQTWVWL1I2UIBKJ4TJjQ==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/rpc-core": "9.14.1",
-        "@polkadot/types": "9.14.1",
-        "@polkadot/types-codec": "9.14.1",
-        "@polkadot/util": "^10.4.1"
+        "@polkadot/rpc-core": "9.14.2",
+        "@polkadot/types": "9.14.2",
+        "@polkadot/types-codec": "9.14.2",
+        "@polkadot/util": "^10.4.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/rpc-core": {
-      "version": "9.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-9.14.1.tgz",
-      "integrity": "sha512-OxbzpDFTvJsHfCbs8DjZJxCyWVeroHUqFwQaQsVQwpbfmSfKf/WxaDTvVGqPw50dfOfCQd9RSndR+52LWQpp2Q==",
+      "version": "9.14.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-9.14.2.tgz",
+      "integrity": "sha512-krA/mtQ5t9nUQEsEVC1sjkttLuzN6z6gyJxK2IlpMS3S5ncy/R6w4FOpy+Q0H18Dn83JBo0p7ZtY7Y6XkK48Kw==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/rpc-augment": "9.14.1",
-        "@polkadot/rpc-provider": "9.14.1",
-        "@polkadot/types": "9.14.1",
-        "@polkadot/util": "^10.4.1",
+        "@polkadot/rpc-augment": "9.14.2",
+        "@polkadot/rpc-provider": "9.14.2",
+        "@polkadot/types": "9.14.2",
+        "@polkadot/util": "^10.4.2",
         "rxjs": "^7.8.0"
       },
       "engines": {
@@ -1333,21 +1333,21 @@
       }
     },
     "node_modules/@polkadot/rpc-provider": {
-      "version": "9.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-9.14.1.tgz",
-      "integrity": "sha512-29EnMJ+7F/62Cdrw92iWvhl+misIeYpX4+a5wZZggBpVb6SSIjj26TzqxxFRG6McZLx/Bh2dKkcFC8qbwINdLw==",
+      "version": "9.14.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-9.14.2.tgz",
+      "integrity": "sha512-YTSywjD5PF01V47Ru5tln2LlpUwJiSOdz6rlJXPpMaY53hUp7+xMU01FVAQ1bllSBNisSD1Msv/mYHq84Oai2g==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/keyring": "^10.4.1",
-        "@polkadot/types": "9.14.1",
-        "@polkadot/types-support": "9.14.1",
-        "@polkadot/util": "^10.4.1",
-        "@polkadot/util-crypto": "^10.4.1",
-        "@polkadot/x-fetch": "^10.4.1",
-        "@polkadot/x-global": "^10.4.1",
-        "@polkadot/x-ws": "^10.4.1",
+        "@polkadot/keyring": "^10.4.2",
+        "@polkadot/types": "9.14.2",
+        "@polkadot/types-support": "9.14.2",
+        "@polkadot/util": "^10.4.2",
+        "@polkadot/util-crypto": "^10.4.2",
+        "@polkadot/x-fetch": "^10.4.2",
+        "@polkadot/x-global": "^10.4.2",
+        "@polkadot/x-ws": "^10.4.2",
         "eventemitter3": "^5.0.0",
-        "mock-socket": "^9.2.0",
+        "mock-socket": "^9.2.1",
         "nock": "^13.3.0"
       },
       "engines": {
@@ -1358,17 +1358,17 @@
       }
     },
     "node_modules/@polkadot/types": {
-      "version": "9.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-9.14.1.tgz",
-      "integrity": "sha512-aFhXTcRbDvj0NulJ0utPNZveyP/vFr+CoLssAEZC8jL+kM0Q80zV2vF8RvWAXFPd46i+JWPSy2ELjpwI/3BqXw==",
+      "version": "9.14.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-9.14.2.tgz",
+      "integrity": "sha512-hGLddTiJbvowhhUZJ3k+olmmBc1KAjWIQxujIUIYASih8FQ3/YJDKxaofGOzh0VygOKW3jxQBN2VZPofyDP9KQ==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/keyring": "^10.4.1",
-        "@polkadot/types-augment": "9.14.1",
-        "@polkadot/types-codec": "9.14.1",
-        "@polkadot/types-create": "9.14.1",
-        "@polkadot/util": "^10.4.1",
-        "@polkadot/util-crypto": "^10.4.1",
+        "@polkadot/keyring": "^10.4.2",
+        "@polkadot/types-augment": "9.14.2",
+        "@polkadot/types-codec": "9.14.2",
+        "@polkadot/types-create": "9.14.2",
+        "@polkadot/util": "^10.4.2",
+        "@polkadot/util-crypto": "^10.4.2",
         "rxjs": "^7.8.0"
       },
       "engines": {
@@ -1376,83 +1376,83 @@
       }
     },
     "node_modules/@polkadot/types-augment": {
-      "version": "9.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-9.14.1.tgz",
-      "integrity": "sha512-/jNdIdfVtnVkO+mXzqvTSDxNMmsSXc434m4dmyVIazCQ8DD/EreA9myHHqQUOGUh+NDXxkhV0RpTmRCx07d0+g==",
+      "version": "9.14.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-9.14.2.tgz",
+      "integrity": "sha512-WO9d7RJufUeY3iFgt2Wz762kOu1tjEiGBR5TT4AHtpEchVHUeosVTrN9eycC+BhleqYu52CocKz6u3qCT/jKLg==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/types": "9.14.1",
-        "@polkadot/types-codec": "9.14.1",
-        "@polkadot/util": "^10.4.1"
+        "@polkadot/types": "9.14.2",
+        "@polkadot/types-codec": "9.14.2",
+        "@polkadot/util": "^10.4.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/types-codec": {
-      "version": "9.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-9.14.1.tgz",
-      "integrity": "sha512-sKas3MD9RTa9EfY7qNdimv5/VktZR/ecK9VcHEKXQt2H4SDUn5afOUjfrhELuKmjEWnhQqzSfp0nCnds2el0SA==",
+      "version": "9.14.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-9.14.2.tgz",
+      "integrity": "sha512-AJ4XF7W1no4PENLBRU955V6gDxJw0h++EN3YoDgThozZ0sj3OxyFupKgNBZcZb2V23H8JxQozzIad8k+nJbO1w==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/util": "^10.4.1",
-        "@polkadot/x-bigint": "^10.4.1"
+        "@polkadot/util": "^10.4.2",
+        "@polkadot/x-bigint": "^10.4.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/types-create": {
-      "version": "9.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-9.14.1.tgz",
-      "integrity": "sha512-Sw7srNZ+3xx/8uWR0wWX2gWGue6GBojZMZkeHVURdF2RNVoYRQB/UQIRFEg7ehjSkBWikVT+Z3a0mntBYATZgA==",
+      "version": "9.14.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-9.14.2.tgz",
+      "integrity": "sha512-nSnKpBierlmGBQT8r6/SHf6uamBIzk4WmdMsAsR4uJKJF1PtbIqx2W5PY91xWSiMSNMzjkbCppHkwaDAMwLGaw==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/types-codec": "9.14.1",
-        "@polkadot/util": "^10.4.1"
+        "@polkadot/types-codec": "9.14.2",
+        "@polkadot/util": "^10.4.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/types-known": {
-      "version": "9.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-9.14.1.tgz",
-      "integrity": "sha512-fF3pKNtie0TxPSYE1MZHu/xKVGCqYLqcdMs/GAvD2+spwSMVAfyefwNB1Yv2FKz3OSUj4OBLnCZT2fmm4HsHnA==",
+      "version": "9.14.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-9.14.2.tgz",
+      "integrity": "sha512-iM8WOCgguzJ3TLMqlm4K1gKQEwWm2zxEKT1HZZ1irs/lAbBk9MquDWDvebryiw3XsLB8xgrp3RTIBn2Q4FjB2A==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/networks": "^10.4.1",
-        "@polkadot/types": "9.14.1",
-        "@polkadot/types-codec": "9.14.1",
-        "@polkadot/types-create": "9.14.1",
-        "@polkadot/util": "^10.4.1"
+        "@polkadot/networks": "^10.4.2",
+        "@polkadot/types": "9.14.2",
+        "@polkadot/types-codec": "9.14.2",
+        "@polkadot/types-create": "9.14.2",
+        "@polkadot/util": "^10.4.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/types-support": {
-      "version": "9.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-9.14.1.tgz",
-      "integrity": "sha512-kjZ8wwyYucWwobrZLxK9v0mkhUZiorFEVHp4QphaKnX9PPaTWxYW68AVlHZdIXmy88k4sl4qDGgthXH3I/04CA==",
+      "version": "9.14.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-9.14.2.tgz",
+      "integrity": "sha512-VWCOPgXDK3XtXT7wMLyIWeNDZxUbNcw/8Pn6n6vMogs7o/n4h6WGbGMeTIQhPWyn831/RmkVs5+2DUC+2LlOhw==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/util": "^10.4.1"
+        "@polkadot/util": "^10.4.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/util": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.1.tgz",
-      "integrity": "sha512-dOlmue4nhbk8msbs/YgoBqVtUzDx5iqhiDnC62GWC8b+JmIlIM4Ddgg1rhBf1KJ6TfEQrzQA0FwLaqCCH5vYmA==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+      "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/x-bigint": "10.4.1",
-        "@polkadot/x-global": "10.4.1",
-        "@polkadot/x-textdecoder": "10.4.1",
-        "@polkadot/x-textencoder": "10.4.1",
+        "@polkadot/x-bigint": "10.4.2",
+        "@polkadot/x-global": "10.4.2",
+        "@polkadot/x-textdecoder": "10.4.2",
+        "@polkadot/x-textencoder": "10.4.2",
         "@types/bn.js": "^5.1.1",
         "bn.js": "^5.2.1"
       },
@@ -1461,18 +1461,18 @@
       }
     },
     "node_modules/@polkadot/util-crypto": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.4.1.tgz",
-      "integrity": "sha512-29vOZLZJl5mNb8lHd2NwP51O7kEV1QOitBX7UsBw66nJOPZQ0imPFPJFGuI6ySPUuck1Lu4vBTC76nE5xpzjAQ==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.4.2.tgz",
+      "integrity": "sha512-RxZvF7C4+EF3fzQv8hZOLrYCBq5+wA+2LWv98nECkroChY3C2ZZvyWDqn8+aonNULt4dCVTWDZM0QIY6y4LUAQ==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "@noble/hashes": "1.2.0",
         "@noble/secp256k1": "1.7.1",
-        "@polkadot/networks": "10.4.1",
-        "@polkadot/util": "10.4.1",
+        "@polkadot/networks": "10.4.2",
+        "@polkadot/util": "10.4.2",
         "@polkadot/wasm-crypto": "^6.4.1",
-        "@polkadot/x-bigint": "10.4.1",
-        "@polkadot/x-randomvalues": "10.4.1",
+        "@polkadot/x-bigint": "10.4.2",
+        "@polkadot/x-randomvalues": "10.4.2",
         "@scure/base": "1.1.1",
         "ed2curve": "^0.3.0",
         "tweetnacl": "^1.0.3"
@@ -1481,7 +1481,7 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "@polkadot/util": "10.4.1"
+        "@polkadot/util": "10.4.2"
       }
     },
     "node_modules/@polkadot/wasm-bridge": {
@@ -1581,24 +1581,24 @@
       }
     },
     "node_modules/@polkadot/x-bigint": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.4.1.tgz",
-      "integrity": "sha512-CpTGPwNUDrJcrnfDU/94mfZ16TZoTwWAwTLH0oMUJtrM2mHo+LtWZBlCTG+thhkcGcSRy/rrpzx4ffNsj5Sy1w==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.4.2.tgz",
+      "integrity": "sha512-awRiox+/XSReLzimAU94fPldowiwnnMUkQJe8AebYhNocAj6SJU00GNoj6j6tAho6yleOwrTJXZaWFBaQVJQNg==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/x-global": "10.4.1"
+        "@polkadot/x-global": "10.4.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/x-fetch": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-10.4.1.tgz",
-      "integrity": "sha512-9LDskIW74Iz5Nen6p9xhVw1D6Z3r/K5buchZW2DERKCA3gZ98wUkTnpHDcwEyLGw0Lvq+1Trvm/txaEMWjUT6w==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-10.4.2.tgz",
+      "integrity": "sha512-Ubb64yaM4qwhogNP+4mZ3ibRghEg5UuCYRMNaCFoPgNAY8tQXuDKrHzeks3+frlmeH9YRd89o8wXLtWouwZIcw==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/x-global": "10.4.1",
+        "@polkadot/x-global": "10.4.2",
         "@types/node-fetch": "^2.6.2",
         "node-fetch": "^3.3.0"
       },
@@ -1607,9 +1607,9 @@
       }
     },
     "node_modules/@polkadot/x-fetch/node_modules/node-fetch": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
-      "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
+      "integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -1624,9 +1624,9 @@
       }
     },
     "node_modules/@polkadot/x-global": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.1.tgz",
-      "integrity": "sha512-Kdh2Fzl1fpEwU6vL1HMaXJy+fadX79eSy4VAnIx/uyCF3H5Z4WaxzoiNVmHdDZSVaamqtbuKepi1nkE3q1nvlA==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+      "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
       "dependencies": {
         "@babel/runtime": "^7.20.13"
       },
@@ -1635,48 +1635,48 @@
       }
     },
     "node_modules/@polkadot/x-randomvalues": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-10.4.1.tgz",
-      "integrity": "sha512-dB4OGOiBbJbNQV040Ggh2CujSXtVe9bxXn1g5LuJEw1iioeraoduJ6yEYmh0olfaQjCUXnyWLr8uCPtPpfJ9uQ==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-10.4.2.tgz",
+      "integrity": "sha512-mf1Wbpe7pRZHO0V3V89isPLqZOy5XGX2bCqsfUWHgb1NvV1MMx5TjVjdaYyNlGTiOkAmJKlOHshcfPU2sYWpNg==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/x-global": "10.4.1"
+        "@polkadot/x-global": "10.4.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/x-textdecoder": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.4.1.tgz",
-      "integrity": "sha512-OcAL0napRM4hukgvH6kYGdiczqvbkFYoLBgQFalZChktjL1tDNiF6tzzt4Nn8WQXYYFlfyxp5LoZRtNrcFJq4w==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.4.2.tgz",
+      "integrity": "sha512-d3ADduOKUTU+cliz839+KCFmi23pxTlabH7qh7Vs1GZQvXOELWdqFOqakdiAjtMn68n1KVF4O14Y+OUm7gp/zA==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/x-global": "10.4.1"
+        "@polkadot/x-global": "10.4.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/x-textencoder": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.4.1.tgz",
-      "integrity": "sha512-YBS04HV/QgRppt0XC5n48c89ueH3ErivrcmqFTlkKMcXNzvtpMCTZGCTzG5vU8ozP0tl/4Is5N8agmYHLMu1Cg==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.4.2.tgz",
+      "integrity": "sha512-mxcQuA1exnyv74Kasl5vxBq01QwckG088lYjc3KwmND6+pPrW2OWagbxFX5VFoDLDAE+UJtnUHsjdWyOTDhpQA==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/x-global": "10.4.1"
+        "@polkadot/x-global": "10.4.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@polkadot/x-ws": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-10.4.1.tgz",
-      "integrity": "sha512-acS2kAAvFOrGo5gVLuOY4DKRschGafvruh491O7jE5r7QbZUNG1Q948g6TA/67I4g8N0k096DYFryID4OK9Ufg==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-10.4.2.tgz",
+      "integrity": "sha512-3gHSTXAWQu1EMcMVTF5QDKHhEHzKxhAArweEyDXE7VsgKUP/ixxw4hVZBrkX122iI5l5mjSiooRSnp/Zl3xqDQ==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/x-global": "10.4.1",
+        "@polkadot/x-global": "10.4.2",
         "@types/websocket": "^1.0.5",
         "websocket": "^1.0.34"
       },
@@ -1780,9 +1780,9 @@
       }
     },
     "node_modules/@substrate/ss58-registry": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.38.0.tgz",
-      "integrity": "sha512-sHiVRWekGMRZAjPukN9/W166NM6D5wtHcK6RVyLy66kg3CHNZ1BXfpXcjOiXSwhbd7guQFDEwnOVaDrbk1XL1g=="
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.39.0.tgz",
+      "integrity": "sha512-qZYpuE6n+mwew+X71dOur/CbMXj6rNW27o63JeJwdQH/GvcSKm3JLNhd+bGzwUKg0D/zD30Qc6p4JykArzM+tA=="
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
@@ -1935,9 +1935,9 @@
       "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA=="
     },
     "node_modules/@types/node-fetch": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
-      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.3.tgz",
+      "integrity": "sha512-ETTL1mOEdq/sxUtgtOhKjyB2Irra4cjxksvcMUR5Zr4n+PxVhsCD9WS46oPbHL3et9Zde7CNRr+WUNlcHvsX+w==",
       "dependencies": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -8238,13 +8238,13 @@
       }
     },
     "@frequency-chain/api-augment": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@frequency-chain/api-augment/-/api-augment-1.2.0.tgz",
-      "integrity": "sha512-tTpygDmUGbQ4AASoWpXHA/n47tavGjlawr+XPM7zqg7D10w6ECtJBOXxoXKN1cw5R9YfStwVeGRgIF+EBEw9sg==",
+      "version": "1.4.0-rc3",
+      "resolved": "https://registry.npmjs.org/@frequency-chain/api-augment/-/api-augment-1.4.0-rc3.tgz",
+      "integrity": "sha512-R2JJZTh6/T34E7NZiLtXxd0ErXfpaZtRtyUN6YG5CYFkfpvYeRav6t+/vUfkWcta7SLgHwa1KfII7VpBTzNeMA==",
       "requires": {
-        "@polkadot/api": "^9.13.2",
-        "@polkadot/rpc-provider": "^9.13.2",
-        "@polkadot/types": "^9.13.2"
+        "@polkadot/api": "^9.14.2",
+        "@polkadot/rpc-provider": "^9.14.2",
+        "@polkadot/types": "^9.14.2"
       }
     },
     "@humanwhocodes/config-array": {
@@ -8612,69 +8612,69 @@
       }
     },
     "@polkadot/api": {
-      "version": "9.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-9.14.1.tgz",
-      "integrity": "sha512-7fQxH6cPOUTH6psEDkaskkgfD+R0CUL0vBYj0BD8e4yxWMsdz4lbuyBl8A6DOVjMD40ZU9HTL3GqQzud5dEdMw==",
+      "version": "9.14.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-9.14.2.tgz",
+      "integrity": "sha512-R3eYFj2JgY1zRb+OCYQxNlJXCs2FA+AU4uIEiVcXnVLmR3M55tkRNEwYAZmiFxx0pQmegGgPMc33q7TWGdw24A==",
       "requires": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/api-augment": "9.14.1",
-        "@polkadot/api-base": "9.14.1",
-        "@polkadot/api-derive": "9.14.1",
-        "@polkadot/keyring": "^10.4.1",
-        "@polkadot/rpc-augment": "9.14.1",
-        "@polkadot/rpc-core": "9.14.1",
-        "@polkadot/rpc-provider": "9.14.1",
-        "@polkadot/types": "9.14.1",
-        "@polkadot/types-augment": "9.14.1",
-        "@polkadot/types-codec": "9.14.1",
-        "@polkadot/types-create": "9.14.1",
-        "@polkadot/types-known": "9.14.1",
-        "@polkadot/util": "^10.4.1",
-        "@polkadot/util-crypto": "^10.4.1",
+        "@polkadot/api-augment": "9.14.2",
+        "@polkadot/api-base": "9.14.2",
+        "@polkadot/api-derive": "9.14.2",
+        "@polkadot/keyring": "^10.4.2",
+        "@polkadot/rpc-augment": "9.14.2",
+        "@polkadot/rpc-core": "9.14.2",
+        "@polkadot/rpc-provider": "9.14.2",
+        "@polkadot/types": "9.14.2",
+        "@polkadot/types-augment": "9.14.2",
+        "@polkadot/types-codec": "9.14.2",
+        "@polkadot/types-create": "9.14.2",
+        "@polkadot/types-known": "9.14.2",
+        "@polkadot/util": "^10.4.2",
+        "@polkadot/util-crypto": "^10.4.2",
         "eventemitter3": "^5.0.0",
         "rxjs": "^7.8.0"
       }
     },
     "@polkadot/api-augment": {
-      "version": "9.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-9.14.1.tgz",
-      "integrity": "sha512-wx9mrNTI3QmO3lfy34KN+TQUwEdgEZzDbZTH8Y+AiQx5hX34oAHTHcKbKoIEF9ENhXhmbNMiEERccH+0GC/1OQ==",
+      "version": "9.14.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-9.14.2.tgz",
+      "integrity": "sha512-19MmW8AHEcLkdcUIo3LLk0eCQgREWqNSxkUyOeWn7UiNMY1AhDOOwMStUBNCvrIDK6VL6GGc1sY7rkPCLMuKSw==",
       "requires": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/api-base": "9.14.1",
-        "@polkadot/rpc-augment": "9.14.1",
-        "@polkadot/types": "9.14.1",
-        "@polkadot/types-augment": "9.14.1",
-        "@polkadot/types-codec": "9.14.1",
-        "@polkadot/util": "^10.4.1"
+        "@polkadot/api-base": "9.14.2",
+        "@polkadot/rpc-augment": "9.14.2",
+        "@polkadot/types": "9.14.2",
+        "@polkadot/types-augment": "9.14.2",
+        "@polkadot/types-codec": "9.14.2",
+        "@polkadot/util": "^10.4.2"
       }
     },
     "@polkadot/api-base": {
-      "version": "9.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-9.14.1.tgz",
-      "integrity": "sha512-bhVZEexTq7qMaq5OoTxjJZgHRA8OPY050tn741JSD5qP9cnZ1xX1H2SElmw3yIlA5juA34V+1gwhxxa4tkDOwA==",
+      "version": "9.14.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-9.14.2.tgz",
+      "integrity": "sha512-ky9fmzG1Tnrjr/SBZ0aBB21l0TFr+CIyQenQczoUyVgiuxVaI/2Bp6R2SFrHhG28P+PW2/RcYhn2oIAR2Z2fZQ==",
       "requires": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/rpc-core": "9.14.1",
-        "@polkadot/types": "9.14.1",
-        "@polkadot/util": "^10.4.1",
+        "@polkadot/rpc-core": "9.14.2",
+        "@polkadot/types": "9.14.2",
+        "@polkadot/util": "^10.4.2",
         "rxjs": "^7.8.0"
       }
     },
     "@polkadot/api-derive": {
-      "version": "9.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-9.14.1.tgz",
-      "integrity": "sha512-urDXH+LHTJHEn5eAT4dOQAGFi3MGa2OnZo0lRYeIkIis9Bl7+Lhh2YKmoL5iFR1BBpmNSL82nlVNjfI2m7oiKA==",
+      "version": "9.14.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-9.14.2.tgz",
+      "integrity": "sha512-yw9OXucmeggmFqBTMgza0uZwhNjPxS7MaT7lSCUIRKckl1GejdV+qMhL3XFxPFeYzXwzFpdPG11zWf+qJlalqw==",
       "requires": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/api": "9.14.1",
-        "@polkadot/api-augment": "9.14.1",
-        "@polkadot/api-base": "9.14.1",
-        "@polkadot/rpc-core": "9.14.1",
-        "@polkadot/types": "9.14.1",
-        "@polkadot/types-codec": "9.14.1",
-        "@polkadot/util": "^10.4.1",
-        "@polkadot/util-crypto": "^10.4.1",
+        "@polkadot/api": "9.14.2",
+        "@polkadot/api-augment": "9.14.2",
+        "@polkadot/api-base": "9.14.2",
+        "@polkadot/rpc-core": "9.14.2",
+        "@polkadot/types": "9.14.2",
+        "@polkadot/types-codec": "9.14.2",
+        "@polkadot/util": "^10.4.2",
+        "@polkadot/util-crypto": "^10.4.2",
         "rxjs": "^7.8.0"
       }
     },
@@ -8703,165 +8703,165 @@
       }
     },
     "@polkadot/keyring": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-10.4.1.tgz",
-      "integrity": "sha512-urTl0ReOr1A1b2kSF6QnGlVc2IcJpDnTacxwA4kIVn45p4Kysi19ek7odSdLA5yNcDZSB+/4uITZQ6meClS71Q==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-10.4.2.tgz",
+      "integrity": "sha512-7iHhJuXaHrRTG6cJDbZE9G+c1ts1dujp0qbO4RfAPmT7YUvphHvAtCKueN9UKPz5+TYDL+rP/jDEaSKU8jl/qQ==",
       "requires": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/util": "10.4.1",
-        "@polkadot/util-crypto": "10.4.1"
+        "@polkadot/util": "10.4.2",
+        "@polkadot/util-crypto": "10.4.2"
       }
     },
     "@polkadot/networks": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-10.4.1.tgz",
-      "integrity": "sha512-kmSy8iAnYKNWXZBv7bTfI10cSLJzOrFFEdngzohHMjDOG5FKoaX3Pix6MUkcWc2asX0hCyACtNTlcp+MBnS9eQ==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-10.4.2.tgz",
+      "integrity": "sha512-FAh/znrEvWBiA/LbcT5GXHsCFUl//y9KqxLghSr/CreAmAergiJNT0MVUezC7Y36nkATgmsr4ylFwIxhVtuuCw==",
       "requires": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/util": "10.4.1",
+        "@polkadot/util": "10.4.2",
         "@substrate/ss58-registry": "^1.38.0"
       }
     },
     "@polkadot/rpc-augment": {
-      "version": "9.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-9.14.1.tgz",
-      "integrity": "sha512-F7pP7YzSrQKDE6LFpfcGIsr1/XLLFwwuIeqyT1nBP9KN9FzykvrDdWaxM0TJqNEf27EFkd3HXeWbGISTPLje0A==",
+      "version": "9.14.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-9.14.2.tgz",
+      "integrity": "sha512-mOubRm3qbKZTbP9H01XRrfTk7k5it9WyzaWAg72DJBQBYdgPUUkGSgpPD/Srkk5/5GAQTWVWL1I2UIBKJ4TJjQ==",
       "requires": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/rpc-core": "9.14.1",
-        "@polkadot/types": "9.14.1",
-        "@polkadot/types-codec": "9.14.1",
-        "@polkadot/util": "^10.4.1"
+        "@polkadot/rpc-core": "9.14.2",
+        "@polkadot/types": "9.14.2",
+        "@polkadot/types-codec": "9.14.2",
+        "@polkadot/util": "^10.4.2"
       }
     },
     "@polkadot/rpc-core": {
-      "version": "9.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-9.14.1.tgz",
-      "integrity": "sha512-OxbzpDFTvJsHfCbs8DjZJxCyWVeroHUqFwQaQsVQwpbfmSfKf/WxaDTvVGqPw50dfOfCQd9RSndR+52LWQpp2Q==",
+      "version": "9.14.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-9.14.2.tgz",
+      "integrity": "sha512-krA/mtQ5t9nUQEsEVC1sjkttLuzN6z6gyJxK2IlpMS3S5ncy/R6w4FOpy+Q0H18Dn83JBo0p7ZtY7Y6XkK48Kw==",
       "requires": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/rpc-augment": "9.14.1",
-        "@polkadot/rpc-provider": "9.14.1",
-        "@polkadot/types": "9.14.1",
-        "@polkadot/util": "^10.4.1",
+        "@polkadot/rpc-augment": "9.14.2",
+        "@polkadot/rpc-provider": "9.14.2",
+        "@polkadot/types": "9.14.2",
+        "@polkadot/util": "^10.4.2",
         "rxjs": "^7.8.0"
       }
     },
     "@polkadot/rpc-provider": {
-      "version": "9.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-9.14.1.tgz",
-      "integrity": "sha512-29EnMJ+7F/62Cdrw92iWvhl+misIeYpX4+a5wZZggBpVb6SSIjj26TzqxxFRG6McZLx/Bh2dKkcFC8qbwINdLw==",
+      "version": "9.14.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-9.14.2.tgz",
+      "integrity": "sha512-YTSywjD5PF01V47Ru5tln2LlpUwJiSOdz6rlJXPpMaY53hUp7+xMU01FVAQ1bllSBNisSD1Msv/mYHq84Oai2g==",
       "requires": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/keyring": "^10.4.1",
-        "@polkadot/types": "9.14.1",
-        "@polkadot/types-support": "9.14.1",
-        "@polkadot/util": "^10.4.1",
-        "@polkadot/util-crypto": "^10.4.1",
-        "@polkadot/x-fetch": "^10.4.1",
-        "@polkadot/x-global": "^10.4.1",
-        "@polkadot/x-ws": "^10.4.1",
+        "@polkadot/keyring": "^10.4.2",
+        "@polkadot/types": "9.14.2",
+        "@polkadot/types-support": "9.14.2",
+        "@polkadot/util": "^10.4.2",
+        "@polkadot/util-crypto": "^10.4.2",
+        "@polkadot/x-fetch": "^10.4.2",
+        "@polkadot/x-global": "^10.4.2",
+        "@polkadot/x-ws": "^10.4.2",
         "@substrate/connect": "0.7.19",
         "eventemitter3": "^5.0.0",
-        "mock-socket": "^9.2.0",
+        "mock-socket": "^9.2.1",
         "nock": "^13.3.0"
       }
     },
     "@polkadot/types": {
-      "version": "9.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-9.14.1.tgz",
-      "integrity": "sha512-aFhXTcRbDvj0NulJ0utPNZveyP/vFr+CoLssAEZC8jL+kM0Q80zV2vF8RvWAXFPd46i+JWPSy2ELjpwI/3BqXw==",
+      "version": "9.14.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-9.14.2.tgz",
+      "integrity": "sha512-hGLddTiJbvowhhUZJ3k+olmmBc1KAjWIQxujIUIYASih8FQ3/YJDKxaofGOzh0VygOKW3jxQBN2VZPofyDP9KQ==",
       "requires": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/keyring": "^10.4.1",
-        "@polkadot/types-augment": "9.14.1",
-        "@polkadot/types-codec": "9.14.1",
-        "@polkadot/types-create": "9.14.1",
-        "@polkadot/util": "^10.4.1",
-        "@polkadot/util-crypto": "^10.4.1",
+        "@polkadot/keyring": "^10.4.2",
+        "@polkadot/types-augment": "9.14.2",
+        "@polkadot/types-codec": "9.14.2",
+        "@polkadot/types-create": "9.14.2",
+        "@polkadot/util": "^10.4.2",
+        "@polkadot/util-crypto": "^10.4.2",
         "rxjs": "^7.8.0"
       }
     },
     "@polkadot/types-augment": {
-      "version": "9.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-9.14.1.tgz",
-      "integrity": "sha512-/jNdIdfVtnVkO+mXzqvTSDxNMmsSXc434m4dmyVIazCQ8DD/EreA9myHHqQUOGUh+NDXxkhV0RpTmRCx07d0+g==",
+      "version": "9.14.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-9.14.2.tgz",
+      "integrity": "sha512-WO9d7RJufUeY3iFgt2Wz762kOu1tjEiGBR5TT4AHtpEchVHUeosVTrN9eycC+BhleqYu52CocKz6u3qCT/jKLg==",
       "requires": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/types": "9.14.1",
-        "@polkadot/types-codec": "9.14.1",
-        "@polkadot/util": "^10.4.1"
+        "@polkadot/types": "9.14.2",
+        "@polkadot/types-codec": "9.14.2",
+        "@polkadot/util": "^10.4.2"
       }
     },
     "@polkadot/types-codec": {
-      "version": "9.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-9.14.1.tgz",
-      "integrity": "sha512-sKas3MD9RTa9EfY7qNdimv5/VktZR/ecK9VcHEKXQt2H4SDUn5afOUjfrhELuKmjEWnhQqzSfp0nCnds2el0SA==",
+      "version": "9.14.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-9.14.2.tgz",
+      "integrity": "sha512-AJ4XF7W1no4PENLBRU955V6gDxJw0h++EN3YoDgThozZ0sj3OxyFupKgNBZcZb2V23H8JxQozzIad8k+nJbO1w==",
       "requires": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/util": "^10.4.1",
-        "@polkadot/x-bigint": "^10.4.1"
+        "@polkadot/util": "^10.4.2",
+        "@polkadot/x-bigint": "^10.4.2"
       }
     },
     "@polkadot/types-create": {
-      "version": "9.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-9.14.1.tgz",
-      "integrity": "sha512-Sw7srNZ+3xx/8uWR0wWX2gWGue6GBojZMZkeHVURdF2RNVoYRQB/UQIRFEg7ehjSkBWikVT+Z3a0mntBYATZgA==",
+      "version": "9.14.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-9.14.2.tgz",
+      "integrity": "sha512-nSnKpBierlmGBQT8r6/SHf6uamBIzk4WmdMsAsR4uJKJF1PtbIqx2W5PY91xWSiMSNMzjkbCppHkwaDAMwLGaw==",
       "requires": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/types-codec": "9.14.1",
-        "@polkadot/util": "^10.4.1"
+        "@polkadot/types-codec": "9.14.2",
+        "@polkadot/util": "^10.4.2"
       }
     },
     "@polkadot/types-known": {
-      "version": "9.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-9.14.1.tgz",
-      "integrity": "sha512-fF3pKNtie0TxPSYE1MZHu/xKVGCqYLqcdMs/GAvD2+spwSMVAfyefwNB1Yv2FKz3OSUj4OBLnCZT2fmm4HsHnA==",
+      "version": "9.14.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-9.14.2.tgz",
+      "integrity": "sha512-iM8WOCgguzJ3TLMqlm4K1gKQEwWm2zxEKT1HZZ1irs/lAbBk9MquDWDvebryiw3XsLB8xgrp3RTIBn2Q4FjB2A==",
       "requires": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/networks": "^10.4.1",
-        "@polkadot/types": "9.14.1",
-        "@polkadot/types-codec": "9.14.1",
-        "@polkadot/types-create": "9.14.1",
-        "@polkadot/util": "^10.4.1"
+        "@polkadot/networks": "^10.4.2",
+        "@polkadot/types": "9.14.2",
+        "@polkadot/types-codec": "9.14.2",
+        "@polkadot/types-create": "9.14.2",
+        "@polkadot/util": "^10.4.2"
       }
     },
     "@polkadot/types-support": {
-      "version": "9.14.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-9.14.1.tgz",
-      "integrity": "sha512-kjZ8wwyYucWwobrZLxK9v0mkhUZiorFEVHp4QphaKnX9PPaTWxYW68AVlHZdIXmy88k4sl4qDGgthXH3I/04CA==",
+      "version": "9.14.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-9.14.2.tgz",
+      "integrity": "sha512-VWCOPgXDK3XtXT7wMLyIWeNDZxUbNcw/8Pn6n6vMogs7o/n4h6WGbGMeTIQhPWyn831/RmkVs5+2DUC+2LlOhw==",
       "requires": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/util": "^10.4.1"
+        "@polkadot/util": "^10.4.2"
       }
     },
     "@polkadot/util": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.1.tgz",
-      "integrity": "sha512-dOlmue4nhbk8msbs/YgoBqVtUzDx5iqhiDnC62GWC8b+JmIlIM4Ddgg1rhBf1KJ6TfEQrzQA0FwLaqCCH5vYmA==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-10.4.2.tgz",
+      "integrity": "sha512-0r5MGICYiaCdWnx+7Axlpvzisy/bi1wZGXgCSw5+ZTyPTOqvsYRqM2X879yxvMsGfibxzWqNzaiVjToz1jvUaA==",
       "requires": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/x-bigint": "10.4.1",
-        "@polkadot/x-global": "10.4.1",
-        "@polkadot/x-textdecoder": "10.4.1",
-        "@polkadot/x-textencoder": "10.4.1",
+        "@polkadot/x-bigint": "10.4.2",
+        "@polkadot/x-global": "10.4.2",
+        "@polkadot/x-textdecoder": "10.4.2",
+        "@polkadot/x-textencoder": "10.4.2",
         "@types/bn.js": "^5.1.1",
         "bn.js": "^5.2.1"
       }
     },
     "@polkadot/util-crypto": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.4.1.tgz",
-      "integrity": "sha512-29vOZLZJl5mNb8lHd2NwP51O7kEV1QOitBX7UsBw66nJOPZQ0imPFPJFGuI6ySPUuck1Lu4vBTC76nE5xpzjAQ==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-10.4.2.tgz",
+      "integrity": "sha512-RxZvF7C4+EF3fzQv8hZOLrYCBq5+wA+2LWv98nECkroChY3C2ZZvyWDqn8+aonNULt4dCVTWDZM0QIY6y4LUAQ==",
       "requires": {
         "@babel/runtime": "^7.20.13",
         "@noble/hashes": "1.2.0",
         "@noble/secp256k1": "1.7.1",
-        "@polkadot/networks": "10.4.1",
-        "@polkadot/util": "10.4.1",
+        "@polkadot/networks": "10.4.2",
+        "@polkadot/util": "10.4.2",
         "@polkadot/wasm-crypto": "^6.4.1",
-        "@polkadot/x-bigint": "10.4.1",
-        "@polkadot/x-randomvalues": "10.4.1",
+        "@polkadot/x-bigint": "10.4.2",
+        "@polkadot/x-randomvalues": "10.4.2",
         "@scure/base": "1.1.1",
         "ed2curve": "^0.3.0",
         "tweetnacl": "^1.0.3"
@@ -8925,29 +8925,29 @@
       }
     },
     "@polkadot/x-bigint": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.4.1.tgz",
-      "integrity": "sha512-CpTGPwNUDrJcrnfDU/94mfZ16TZoTwWAwTLH0oMUJtrM2mHo+LtWZBlCTG+thhkcGcSRy/rrpzx4ffNsj5Sy1w==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-10.4.2.tgz",
+      "integrity": "sha512-awRiox+/XSReLzimAU94fPldowiwnnMUkQJe8AebYhNocAj6SJU00GNoj6j6tAho6yleOwrTJXZaWFBaQVJQNg==",
       "requires": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/x-global": "10.4.1"
+        "@polkadot/x-global": "10.4.2"
       }
     },
     "@polkadot/x-fetch": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-10.4.1.tgz",
-      "integrity": "sha512-9LDskIW74Iz5Nen6p9xhVw1D6Z3r/K5buchZW2DERKCA3gZ98wUkTnpHDcwEyLGw0Lvq+1Trvm/txaEMWjUT6w==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-10.4.2.tgz",
+      "integrity": "sha512-Ubb64yaM4qwhogNP+4mZ3ibRghEg5UuCYRMNaCFoPgNAY8tQXuDKrHzeks3+frlmeH9YRd89o8wXLtWouwZIcw==",
       "requires": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/x-global": "10.4.1",
+        "@polkadot/x-global": "10.4.2",
         "@types/node-fetch": "^2.6.2",
         "node-fetch": "^3.3.0"
       },
       "dependencies": {
         "node-fetch": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
-          "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
+          "integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
           "requires": {
             "data-uri-to-buffer": "^4.0.0",
             "fetch-blob": "^3.1.4",
@@ -8957,47 +8957,47 @@
       }
     },
     "@polkadot/x-global": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.1.tgz",
-      "integrity": "sha512-Kdh2Fzl1fpEwU6vL1HMaXJy+fadX79eSy4VAnIx/uyCF3H5Z4WaxzoiNVmHdDZSVaamqtbuKepi1nkE3q1nvlA==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-10.4.2.tgz",
+      "integrity": "sha512-g6GXHD/ykZvHap3M6wh19dO70Zm43l4jEhlxf5LtTo5/0/UporFCXr2YJYZqfbn9JbQwl1AU+NroYio+vtJdiA==",
       "requires": {
         "@babel/runtime": "^7.20.13"
       }
     },
     "@polkadot/x-randomvalues": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-10.4.1.tgz",
-      "integrity": "sha512-dB4OGOiBbJbNQV040Ggh2CujSXtVe9bxXn1g5LuJEw1iioeraoduJ6yEYmh0olfaQjCUXnyWLr8uCPtPpfJ9uQ==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-10.4.2.tgz",
+      "integrity": "sha512-mf1Wbpe7pRZHO0V3V89isPLqZOy5XGX2bCqsfUWHgb1NvV1MMx5TjVjdaYyNlGTiOkAmJKlOHshcfPU2sYWpNg==",
       "requires": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/x-global": "10.4.1"
+        "@polkadot/x-global": "10.4.2"
       }
     },
     "@polkadot/x-textdecoder": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.4.1.tgz",
-      "integrity": "sha512-OcAL0napRM4hukgvH6kYGdiczqvbkFYoLBgQFalZChktjL1tDNiF6tzzt4Nn8WQXYYFlfyxp5LoZRtNrcFJq4w==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-10.4.2.tgz",
+      "integrity": "sha512-d3ADduOKUTU+cliz839+KCFmi23pxTlabH7qh7Vs1GZQvXOELWdqFOqakdiAjtMn68n1KVF4O14Y+OUm7gp/zA==",
       "requires": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/x-global": "10.4.1"
+        "@polkadot/x-global": "10.4.2"
       }
     },
     "@polkadot/x-textencoder": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.4.1.tgz",
-      "integrity": "sha512-YBS04HV/QgRppt0XC5n48c89ueH3ErivrcmqFTlkKMcXNzvtpMCTZGCTzG5vU8ozP0tl/4Is5N8agmYHLMu1Cg==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-10.4.2.tgz",
+      "integrity": "sha512-mxcQuA1exnyv74Kasl5vxBq01QwckG088lYjc3KwmND6+pPrW2OWagbxFX5VFoDLDAE+UJtnUHsjdWyOTDhpQA==",
       "requires": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/x-global": "10.4.1"
+        "@polkadot/x-global": "10.4.2"
       }
     },
     "@polkadot/x-ws": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-10.4.1.tgz",
-      "integrity": "sha512-acS2kAAvFOrGo5gVLuOY4DKRschGafvruh491O7jE5r7QbZUNG1Q948g6TA/67I4g8N0k096DYFryID4OK9Ufg==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-10.4.2.tgz",
+      "integrity": "sha512-3gHSTXAWQu1EMcMVTF5QDKHhEHzKxhAArweEyDXE7VsgKUP/ixxw4hVZBrkX122iI5l5mjSiooRSnp/Zl3xqDQ==",
       "requires": {
         "@babel/runtime": "^7.20.13",
-        "@polkadot/x-global": "10.4.1",
+        "@polkadot/x-global": "10.4.2",
         "@types/websocket": "^1.0.5",
         "websocket": "^1.0.34"
       }
@@ -9082,9 +9082,9 @@
       }
     },
     "@substrate/ss58-registry": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.38.0.tgz",
-      "integrity": "sha512-sHiVRWekGMRZAjPukN9/W166NM6D5wtHcK6RVyLy66kg3CHNZ1BXfpXcjOiXSwhbd7guQFDEwnOVaDrbk1XL1g=="
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.39.0.tgz",
+      "integrity": "sha512-qZYpuE6n+mwew+X71dOur/CbMXj6rNW27o63JeJwdQH/GvcSKm3JLNhd+bGzwUKg0D/zD30Qc6p4JykArzM+tA=="
     },
     "@tootallnate/once": {
       "version": "2.0.0",
@@ -9234,9 +9234,9 @@
       "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA=="
     },
     "@types/node-fetch": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
-      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.3.tgz",
+      "integrity": "sha512-ETTL1mOEdq/sxUtgtOhKjyB2Irra4cjxksvcMUR5Zr4n+PxVhsCD9WS46oPbHL3et9Zde7CNRr+WUNlcHvsX+w==",
       "requires": {
         "@types/node": "*",
         "form-data": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/LibertyDSNP/schemas#readme",
   "dependencies": {
-    "@frequency-chain/api-augment": "1.4.0-rc3",
+    "@frequency-chain/api-augment": "1.5.1",
     "@polkadot/api": "^9.14.1",
     "@polkadot/extension-dapp": "^0.44.6",
     "@polkadot/types": "^9.14.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/LibertyDSNP/schemas#readme",
   "dependencies": {
-    "@frequency-chain/api-augment": "1.2.0",
+    "@frequency-chain/api-augment": "1.4.0-rc3",
     "@polkadot/api": "^9.14.1",
     "@polkadot/extension-dapp": "^0.44.6",
     "@polkadot/types": "^9.14.1",

--- a/read.ts
+++ b/read.ts
@@ -3,23 +3,9 @@ import { getEndpoint, getFrequencyAPI } from "./services/connect";
 
 import stringify from "json-stringify-pretty-compact";
 
-import broadcast from "./dsnp/broadcast";
-import graphChange from "./dsnp/graphChange";
-import profile from "./dsnp/profile";
-import reaction from "./dsnp/reaction";
-import reply from "./dsnp/reply";
-import tombstone from "./dsnp/tombstone";
-import update from "./dsnp/update";
+import { dsnpSchemas } from "./dsnp";
 
-const nameAndSchema = [
-  ["dsnp.broadcast", JSON.stringify(broadcast)],
-  ["dsnp.profile", JSON.stringify(profile)],
-  ["dsnp.reaction", JSON.stringify(reaction)],
-  ["dsnp.reply", JSON.stringify(reply)],
-  ["dsnp.tombstone", JSON.stringify(tombstone)],
-  ["dsnp.update", JSON.stringify(update)],
-  ["dsnp.graphChange", JSON.stringify(graphChange)],
-];
+const nameAndSchema = Array.from(dsnpSchemas.entries(), ([k, v]) => [`dsnp.${k}`, JSON.stringify(v.model)]);
 
 const read = async () => {
   const api = await getFrequencyAPI();


### PR DESCRIPTION
Problem
=======

Needed to add the schemas for the upcoming DSNP 1.2.0 release.

Change summary:
---------------
* Updated the DSNP schemas for 1.2.0
* Updated to Frequency 1.5.1
* Cleaned up the deploy and read logic and made it easier to add new DSNP Schemas

Steps to Verify:
----------------
1. Run Frequency 1.4.0+ locally
1. `npm run deploy`
1. `npm run read`
1. See that they all deployed and are working!
