### PR TITLE
[Paused] added lastUpdated in UserPrivateGraphChunk

### DIFF
--- a/dsnp/userPrivateGraph.spec.ts
+++ b/dsnp/userPrivateGraph.spec.ts
@@ -30,10 +30,18 @@ describe("Private Graph Schema", () => {
       type: "long",
     });
 
+    const lastUpdatedType = avro.parse({
+      name: "lastUpdated",
+      type: "long",
+    });
+
+    const lastUpdated = lastUpdatedType.random();
+
     // Generate the outside and buffer
     const outsideBuffer = outsideType.toBuffer({
       keyId: keyIdType.random(),
       pridList,
+      lastUpdated,
       encryptedCompressedPrivateGraph: insideBuffer,
     });
 
@@ -43,6 +51,9 @@ describe("Private Graph Schema", () => {
 
     // Check the inside parsed data is the same as the original.
     expect(insideParsed).toEqual(inside);
+
+    // check lastUpdated
+    expect(outsideParsed.lastUpdated).toEqual(lastUpdated);
 
     // Also check the pridList, but that is just testing Avro
     expect(outsideParsed.pridList).toEqual(pridList);

--- a/dsnp/userPrivateGraph.ts
+++ b/dsnp/userPrivateGraph.ts
@@ -22,6 +22,11 @@ export default {
       },
     },
     {
+      name: "lastUpdated",
+      type: "long",
+      doc: "Days since Unix epoch when PRIds for this chunk were last refreshed",
+    },
+    {
       doc: "lib_sodium sealed box",
       name: "encryptedCompressedPrivateGraph",
       type: "bytes",


### PR DESCRIPTION
Problem
=======
We will need to know when was the last time that all Prids inside a page got refreshed. This will allow us to determine which pages need to be updated by refreshing their PRId. This is important to ensure that an un-delegated provider would not be able to check Friendship status for an extended period of time.

closes #27 

Solution
========
Added a new field named `lastUpdated`  to UserPrivateGraphChunk

Status
========
This is currently paused and should not get merged until we are absolutely convinced that it is necessary.