### PR TITLE
Update publicKey to use the index

### DIFF
--- a/dsnp/publicKey.ts
+++ b/dsnp/publicKey.ts
@@ -13,6 +13,6 @@ export default {
       name: "publicKey",
       doc: "Multicodec public key",
       type: "bytes",
-    }
+    },
   ],
 };

--- a/dsnp/publicKey.ts
+++ b/dsnp/publicKey.ts
@@ -7,16 +7,12 @@ export default {
     // - announcementType = 7
     // - fromId = [Associated MSA Id]
     // - keyType = 1 for this SchemaId
+    // - keyId = `index` from the Itemized storage
     // DID Key Id could be publicKey or could be the index of the array. Not user assigned
     {
       name: "publicKey",
       doc: "Multicodec public key",
       type: "bytes",
-    },
-    {
-      name: "keyId",
-      type: "long",
-      doc: "User-Assigned Key Identifier",
-    },
+    }
   ],
 };

--- a/dsnp/userPrivateConnections.ts
+++ b/dsnp/userPrivateConnections.ts
@@ -10,6 +10,7 @@ export default {
       doc: "User-Assigned Key Identifier",
     },
     {
+      // The PRId List should be ordered the same as the GraphEdges
       name: "pridList",
       type: {
         type: "array",


### PR DESCRIPTION
Instead of using a user provided value.

Itemized storage already provides a unique id per item.

Also added a clarifying comment to UserPrivateConnection