### PR TITLE
fix(missing-export): add userPublicFollows to default exports

### DIFF
--- a/dsnp/index.ts
+++ b/dsnp/index.ts
@@ -22,6 +22,7 @@ export {
   publicKey,
   userPrivateFollows,
   userPrivateConnections,
+  userPublicFollows,
   update,
 };
 

--- a/scripts/package.cjs
+++ b/scripts/package.cjs
@@ -25,12 +25,31 @@ rootPackage["module"] = "./esm/index.js";
 rootPackage["types"] = "index.d.ts";
 rootPackage["exports"] = {
   ".": {
-    "types": "./index.d.ts",
-    "require": "./cjs/index.js",
-    "import": "./esm/index.js",
-    "default": "./esm/index.js"
+    types: "./index.d.ts",
+    require: "./cjs/index.js",
+    import: "./esm/index.js",
+    default: "./esm/index.js",
   },
-},
+};
+
+// Submodules
+["parquet"].forEach((sub) => {
+  rootPackage["exports"][`./${sub}`] = {
+    types: `./${sub}.d.ts`,
+    require: `./cjs/${sub}.js`,
+    import: `./esm/${sub}.js`,
+    default: `./esm/${sub}.js`,
+  };
+});
+
+["dsnp"].forEach((sub) => {
+  rootPackage["exports"][`./${sub}`] = {
+    types: `./${sub}/index.d.ts`,
+    require: `./cjs/${sub}/index.js`,
+    import: `./esm/${sub}/index.js`,
+    default: `./esm/${sub}/index.js`,
+  };
+});
 
 // Write it out
 fs.writeFileSync(`${path.join(__dirname, "../dist", "package.json")}`, JSON.stringify(rootPackage, null, 2), (err) => {
@@ -38,11 +57,19 @@ fs.writeFileSync(`${path.join(__dirname, "../dist", "package.json")}`, JSON.stri
 });
 
 // Write out a simple type override for the esm side of things
-fs.writeFileSync(`${path.join(__dirname, "../dist/esm", "package.json")}`, JSON.stringify({ "type": "module" }, null, 2), (err) => {
-  if (err) throw new Error(err);
-});
+fs.writeFileSync(
+  `${path.join(__dirname, "../dist/esm", "package.json")}`,
+  JSON.stringify({ type: "module" }, null, 2),
+  (err) => {
+    if (err) throw new Error(err);
+  }
+);
 
 // Write out a simple type override for the cjs side of things
-fs.writeFileSync(`${path.join(__dirname, "../dist/cjs", "package.json")}`, JSON.stringify({ "type": "commonjs" }, null, 2), (err) => {
-  if (err) throw new Error(err);
-});
+fs.writeFileSync(
+  `${path.join(__dirname, "../dist/cjs", "package.json")}`,
+  JSON.stringify({ type: "commonjs" }, null, 2),
+  (err) => {
+    if (err) throw new Error(err);
+  }
+);


### PR DESCRIPTION
Problem
=======
Package is missing `userPublicFollows` from default exports

Closes: #34 

Solution
========
Adds `userPublicFollows` to default exports
Also updates the packaging script to export the sub-modules `dsnp` and `parquet` properly.

Double Checks:
---------------
- [] Did you update the changelog?
- [] Do you have good documentation on exported methods?

Change summary:
---------------
* Tidy, well formulated commit message
* Another great commit message
* Something else I/we did

Steps to Verify:
----------------
1. A setup step / beginning state
1. What to do next
1. Any other instructions
1. Expected behavior
1. Suggestions for testing
