### PR TITLE
Export both CJS and ESM sub-modules properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "@dsnp/frequency-schemas",
   "version": "0.0.0",
   "description": "Schemas for DSNP on Frequency",
-  "type": "module",
   "scripts": {
     "test": "jest",
     "deploy": "node --loader ts-node/esm cli/index.ts",

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,9 +1,7 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
-        "lib": ["ES2020"],
         "module": "CommonJS",
         "outDir": "dist/cjs",
-        "declaration": false
     },
 }

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,7 +1,6 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
-        "lib": ["ES2020"],
         "module": "ES2022",
         "outDir": "dist/esm",
         "declaration": false

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,12 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Base",
   "compilerOptions": {
+      "allowJs": true,
       "allowSyntheticDefaultImports": true,
+      "declaration": false,
       "esModuleInterop": true,
+      "lib": ["ES2022"],
       "moduleResolution": "node",
-      "module": "esnext",
       "noImplicitAny": true,
       "outDir": "dist",
       "resolveJsonModule": true,


### PR DESCRIPTION
Problem
=======
problem statement

Closes: #37 

Solution
========
Updated packaging scripts to properly export for use by both ESM and CJS projects.

Double Checks:
---------------
- [] Did you update the changelog?
- [] Do you have good documentation on exported methods?

Change summary:
---------------
* Tidy, well formulated commit message
* Another great commit message
* Something else I/we did

Steps to Verify:
----------------
1. A setup step / beginning state
1. What to do next
1. Any other instructions
1. Expected behavior
1. Suggestions for testing
