### PR TITLE
Add js to imports and fix dsnp export paths

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -52,5 +52,6 @@
       }
     ],
     "allow-namespace": "off",
+    "import/extensions": ["error", "always", { "ignorePackages": true } ]
   }
 }

--- a/cli/deploy.ts
+++ b/cli/deploy.ts
@@ -1,5 +1,5 @@
-import { getFrequencyAPI, getSignerAccountKeys } from "./services/connect";
-import dsnp, { SchemaName as DsnpSchemaName } from "../dsnp";
+import { getFrequencyAPI, getSignerAccountKeys } from "./services/connect.js";
+import dsnp, { SchemaName as DsnpSchemaName } from "../dsnp/index.js";
 import { EventRecord } from "@polkadot/types/interfaces";
 
 export const deploy = async () => {

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,4 +1,4 @@
-import { deploy } from "./deploy";
+import { deploy } from "./deploy.js";
 
 export const main = async () => {
   await deploy();

--- a/cli/read.ts
+++ b/cli/read.ts
@@ -1,8 +1,8 @@
-import { getEndpoint, getFrequencyAPI } from "./services/connect";
+import { getEndpoint, getFrequencyAPI } from "./services/connect.js";
 
 import stringify from "json-stringify-pretty-compact";
 
-import { schemas } from "../dsnp";
+import { schemas } from "../dsnp/index.js";
 
 const nameAndSchema = Array.from(schemas.entries(), ([k, v]) => [`dsnp.${k}`, JSON.stringify(v.model)]);
 

--- a/dsnp/broadcast.spec.ts
+++ b/dsnp/broadcast.spec.ts
@@ -1,6 +1,6 @@
-import { testCompression, testParquetSchema } from "../test/parquet";
+import { testCompression, testParquetSchema } from "../test/parquet.js";
 import * as generators from "@dsnp/test-generators";
-import broadcastSchema from "./broadcast";
+import broadcastSchema from "./broadcast.js";
 
 describe("Broadcast Spec", () => {
   testParquetSchema(broadcastSchema);

--- a/dsnp/broadcast.ts
+++ b/dsnp/broadcast.ts
@@ -1,4 +1,4 @@
-import { FrequencyParquetSchema } from "../types/frequency";
+import { FrequencyParquetSchema } from "../types/frequency.js";
 
 const broadcast: FrequencyParquetSchema = [
   {

--- a/dsnp/graphChange.spec.ts
+++ b/dsnp/graphChange.spec.ts
@@ -1,4 +1,4 @@
-import graphChangeSchema from "./graphChange";
+import graphChangeSchema from "./graphChange.js";
 import avro from "avro-js";
 
 describe("Graph Change Schema", () => {

--- a/dsnp/index.ts
+++ b/dsnp/index.ts
@@ -1,17 +1,17 @@
-import { FrequencyParquetSchema } from "../types/frequency";
+import { FrequencyParquetSchema } from "../types/frequency.js";
 
-import broadcast from "./broadcast";
+import broadcast from "./broadcast.js";
 // Deprecated
-// import graphChange from "./dsnp/graphChange";
-import profile from "./profile";
-import reaction from "./reaction";
-import reply from "./reply";
-import tombstone from "./tombstone";
-import publicKey from "./publicKey";
-import userPublicFollows from "./userPublicFollows";
-import userPrivateFollows from "./userPrivateFollows";
-import userPrivateConnections from "./userPrivateConnections";
-import update from "./update";
+// import graphChange from "./dsnp/graphChange.js";
+import profile from "./profile.js";
+import reaction from "./reaction.js";
+import reply from "./reply.js";
+import tombstone from "./tombstone.js";
+import publicKey from "./publicKey.js";
+import userPublicFollows from "./userPublicFollows.js";
+import userPrivateFollows from "./userPrivateFollows.js";
+import userPrivateConnections from "./userPrivateConnections.js";
+import update from "./update.js";
 
 export {
   broadcast,

--- a/dsnp/profile.spec.ts
+++ b/dsnp/profile.spec.ts
@@ -1,6 +1,6 @@
-import { testCompression, testParquetSchema } from "../test/parquet";
+import { testCompression, testParquetSchema } from "../test/parquet.js";
 import * as generators from "@dsnp/test-generators";
-import profileSchema from "./profile";
+import profileSchema from "./profile.js";
 
 describe("Profile Spec", () => {
   testParquetSchema(profileSchema);

--- a/dsnp/profile.ts
+++ b/dsnp/profile.ts
@@ -1,4 +1,4 @@
-import { FrequencyParquetSchema } from "../types/frequency";
+import { FrequencyParquetSchema } from "../types/frequency.js";
 
 const profile: FrequencyParquetSchema = [
   {

--- a/dsnp/publicKey.spec.ts
+++ b/dsnp/publicKey.spec.ts
@@ -1,4 +1,4 @@
-import publicKeySchema from "./publicKey";
+import publicKeySchema from "./publicKey.js";
 import avro from "avro-js";
 
 describe("Public Key Schema", () => {

--- a/dsnp/reaction.spec.ts
+++ b/dsnp/reaction.spec.ts
@@ -1,6 +1,6 @@
-import { testCompression, testParquetSchema } from "../test/parquet";
+import { testCompression, testParquetSchema } from "../test/parquet.js";
 import * as generators from "@dsnp/test-generators";
-import reactionSchema from "./reaction";
+import reactionSchema from "./reaction.js";
 
 describe("Reaction Spec", () => {
   testParquetSchema(reactionSchema);

--- a/dsnp/reaction.ts
+++ b/dsnp/reaction.ts
@@ -1,4 +1,4 @@
-import { FrequencyParquetSchema } from "../types/frequency";
+import { FrequencyParquetSchema } from "../types/frequency.js";
 
 const reaction: FrequencyParquetSchema = [
   {

--- a/dsnp/reply.spec.ts
+++ b/dsnp/reply.spec.ts
@@ -1,6 +1,6 @@
-import { testCompression, testParquetSchema } from "../test/parquet";
+import { testCompression, testParquetSchema } from "../test/parquet.js";
 import * as generators from "@dsnp/test-generators";
-import replySchema from "./reply";
+import replySchema from "./reply.js";
 
 describe("Reply Spec", () => {
   testParquetSchema(replySchema);

--- a/dsnp/reply.ts
+++ b/dsnp/reply.ts
@@ -1,4 +1,4 @@
-import { FrequencyParquetSchema } from "../types/frequency";
+import { FrequencyParquetSchema } from "../types/frequency.js";
 
 const reply: FrequencyParquetSchema = [
   {

--- a/dsnp/tombstone.spec.ts
+++ b/dsnp/tombstone.spec.ts
@@ -1,6 +1,6 @@
-import { testCompression, testParquetSchema } from "../test/parquet";
+import { testCompression, testParquetSchema } from "../test/parquet.js";
 import * as generators from "@dsnp/test-generators";
-import tombstoneSchema from "./tombstone";
+import tombstoneSchema from "./tombstone.js";
 
 describe("Tombstone Spec", () => {
   testParquetSchema(tombstoneSchema);

--- a/dsnp/tombstone.ts
+++ b/dsnp/tombstone.ts
@@ -1,4 +1,4 @@
-import { FrequencyParquetSchema } from "../types/frequency";
+import { FrequencyParquetSchema } from "../types/frequency.js";
 
 const tombstone: FrequencyParquetSchema = [
   {

--- a/dsnp/update.spec.ts
+++ b/dsnp/update.spec.ts
@@ -1,6 +1,6 @@
-import { testCompression, testParquetSchema } from "../test/parquet";
+import { testCompression, testParquetSchema } from "../test/parquet.js";
 import * as generators from "@dsnp/test-generators";
-import updateSchema from "./update";
+import updateSchema from "./update.js";
 
 describe("Update Spec", () => {
   testParquetSchema(updateSchema);

--- a/dsnp/update.ts
+++ b/dsnp/update.ts
@@ -1,4 +1,4 @@
-import { FrequencyParquetSchema } from "../types/frequency";
+import { FrequencyParquetSchema } from "../types/frequency.js";
 
 const update: FrequencyParquetSchema = [
   {

--- a/dsnp/userPrivateConnections.spec.ts
+++ b/dsnp/userPrivateConnections.spec.ts
@@ -1,4 +1,4 @@
-import privateConnectionsSchema from "./userPrivateConnections";
+import privateConnectionsSchema from "./userPrivateConnections.js";
 import avro from "avro-js";
 
 describe("Private Connections Schema", () => {

--- a/dsnp/userPrivateFollows.spec.ts
+++ b/dsnp/userPrivateFollows.spec.ts
@@ -1,4 +1,4 @@
-import privateFollowsSchema from "./userPrivateFollows";
+import privateFollowsSchema from "./userPrivateFollows.js";
 import avro from "avro-js";
 
 describe("Private Follows Schema", () => {

--- a/dsnp/userPublicFollows.spec.ts
+++ b/dsnp/userPublicFollows.spec.ts
@@ -1,4 +1,4 @@
-import publicFollowsSchema from "./userPublicFollows";
+import publicFollowsSchema from "./userPublicFollows.js";
 import avro from "avro-js";
 
 describe("Public Follows Schema", () => {

--- a/index.ts
+++ b/index.ts
@@ -1,2 +1,2 @@
-export * as dsnp from "./dsnp";
-export * as parquet from "./parquet";
+export * as dsnp from "./dsnp/index.js";
+export * as parquet from "./parquet.js";

--- a/parquet.spec.ts
+++ b/parquet.spec.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import { ParquetWriter, ParquetReader } from "@dsnp/parquetjs";
-import { fromFrequencySchema } from "./parquet";
-import { broadcast } from "./dsnp";
+import { fromFrequencySchema } from "./parquet.js";
+import { broadcast } from "./dsnp/index.js";
 
 describe("Frequency Schema Conversion Test File", () => {
   const [parquetSchema, writerOptions] = fromFrequencySchema(broadcast);

--- a/parquet.ts
+++ b/parquet.ts
@@ -1,8 +1,8 @@
 import { ParquetSchema } from "@dsnp/parquetjs";
 import type { ParquetType, FieldDefinition, SchemaDefinition, WriterOptions } from "@dsnp/parquetjs/dist/lib/declare";
 import type { createSBBFParams } from "@dsnp/parquetjs/dist/lib/bloomFilterIO/bloomFilterWriter";
-import { FrequencyParquetSchema, FrequencyParquetType, ParquetColumn } from "./types/frequency";
-import * as dsnp from "./dsnp";
+import { FrequencyParquetSchema, FrequencyParquetType, ParquetColumn } from "./types/frequency.js";
+import * as dsnp from "./dsnp/index.js";
 
 /**
  * All supported types from Parquetjs

--- a/scripts/package.cjs
+++ b/scripts/package.cjs
@@ -33,7 +33,7 @@ rootPackage["exports"] = {
 };
 
 // Submodules
-["parquet", "dsnp/index", "cli/deploy"].forEach((sub) => {
+["parquet", "cli/deploy"].forEach((sub) => {
   rootPackage["exports"][`./${sub}`] = {
     types: `./${sub}.d.ts`,
     require: `./cjs/${sub}.js`,
@@ -41,6 +41,14 @@ rootPackage["exports"] = {
     default: `./esm/${sub}.js`,
   };
 });
+
+// DSNP module
+rootPackage["exports"][`./dsnp`] = {
+  types: `./dsnp/index.d.ts`,
+  require: `./cjs/dsnp/index.js`,
+  import: `./esm/dsnp/index.js`,
+  default: `./esm/dsnp/index.js`,
+};
 
 // Write it out
 fs.writeFileSync(`${path.join(__dirname, "../dist", "package.json")}`, JSON.stringify(rootPackage, null, 2), (err) => {

--- a/test/parquet.ts
+++ b/test/parquet.ts
@@ -1,8 +1,8 @@
 /* eslint-disable jest/no-export */
 import fs from "fs";
 import { ParquetWriter } from "@dsnp/parquetjs";
-import { FrequencyParquetSchema } from "../types/frequency";
-import { fromFrequencySchema } from "../parquet";
+import { FrequencyParquetSchema } from "../types/frequency.js";
+import { fromFrequencySchema } from "../parquet.js";
 
 type RowGenerator = () => Record<string, unknown>;
 


### PR DESCRIPTION
Problem
=======

To make sure that the generated javascript can be used directly with node 16+ and in browsers when using es modules, we needed to use the full path

See: https://nodejs.org/dist/latest-v14.x/docs/api/esm.html#esm_resolution_algorithm

Solution
========
- Added the `.js`
- Added the linter to enforce it

Steps to Verify:
----------------
1. `npm run build`
1. See that the outputs are correct
1. `cd dist && npm pack`
1. Install the generated dsnp-frequency-schemas-0.0.0.tgz file in a package that runs with node js
