### PR TITLE
185915055: Added touchfile

### DIFF
--- a/scripts/deploy_schemas_to_node.sh
+++ b/scripts/deploy_schemas_to_node.sh
@@ -25,4 +25,7 @@ whoami
 cd frequency/schemas
 npm run deploy
 
+touch successTouchFile
+echo "CREATED TOUCHFILE"
+
 fg %1


### PR DESCRIPTION
The idea here is you can test for the touchfile for the Docker healthcheck command or for some other things, like the Testcontainers framework, you can look for the log message to start up ASAP and not be at the whims of the interval of the Docker healthcheck. This will greatly speed up tests

Problem
=======
To speed up tests and not uses the Docker Healthcheck I've added a log statement that triggers our Testcontainers to know the node is up

Change summary:
---------------
* I line echo statement

Steps to Verify:
----------------
1. I tested the Docker container via the custodial wallet application
