### PR TITLE
Changed CLI properties to match what is around now

### DIFF
--- a/scripts/deploy_schemas_to_node.sh
+++ b/scripts/deploy_schemas_to_node.sh
@@ -13,11 +13,9 @@ whoami
     --no-telemetry \
     --no-prometheus \
     --port=30333 \
-    --rpc-port=9933 \
-    --ws-port=9944 \
+    --rpc-port=9944 \
     --rpc-external \
     --rpc-cors=all \
-    --ws-external \
     --rpc-methods=Unsafe \
     --base-path=/data \
     &


### PR DESCRIPTION
Some were outright deprecated and some collpased into the same property. You can see the information on what happened here https://github.com/paritytech/substrate/pull/13384

Problem
=======
A lot of CLI properties were deprecated or collapsed, this fixes our script that deploys schemas for a convenience container to use for testing

Solution
========
Matched the CLI Properties to what they are today

Change summary:
---------------
* Same as above

Steps to Verify:
----------------
1. Use a project that uses that container and test, my projects pass
