### PR TITLE
Chore Update Versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
 
 # Install node-js to base image
 RUN apt-get update && apt-get install -y curl gnupg \
-        && curl -sL https://deb.nodesource.com/setup_16.x | bash \
+        && curl -sL https://deb.nodesource.com/setup_18.x | bash \
         && apt-get update && apt-get install -y nodejs \
         && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,15 +40,13 @@ ENV TINI_VERSION v0.19.0
 ADD --chown=frequency https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
-# 9933 P2P port
-# 9944 for RPC call
-# 30333 for Websocket
-EXPOSE 9933 9944 30333
+# 9944 for RPC/Websocket
+EXPOSE 9944
 
 VOLUME ["/data"]
 
 HEALTHCHECK --start-period=15s \
-  CMD curl --fail -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "rpc_methods"}' http://localhost:9933/ || exit 1
+  CMD curl --fail -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "rpc_methods"}' http://localhost:9944/ || exit 1
 
 ENTRYPOINT ["/tini", "--"]
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ This repo includes a docker image to push a [Frequency instant-seal-node](https:
 ### Run Locally
 For any local testing do the following:
 1. `docker pull dsnp/instant-seal-node-with-deployed-schemas:latest`
-2. `docker run docker run --rm -p 9944:9944 -p 9933:9933 -p 30333:30333 dsnp/instant-seal-node-with-deployed-schemas:latest`
+2. `docker run docker run --rm -p 9944:9944 dsnp/instant-seal-node-with-deployed-schemas:latest`
 
 ### Build Locally
 1. `docker build -t dsnp/instant-seal-node-with-deployed-schemas:latest -t dsnp/instant-seal-node-with-deployed-schemas:<versionNumberHere> .`

--- a/scripts/deploy_schemas_to_node.sh
+++ b/scripts/deploy_schemas_to_node.sh
@@ -12,7 +12,6 @@ whoami
     --sealing=instant \
     --no-telemetry \
     --no-prometheus \
-    --port=30333 \
     --rpc-port=9944 \
     --rpc-external \
     --rpc-cors=all \


### PR DESCRIPTION
Change summary:
---------------
* Removed unused p2p port references (instant seal does not use p2p)
* Updated for [v1.8.0](https://github.com/LibertyDSNP/frequency/releases/tag/v1.8.0) of Frequency which removes separate rpc port
* Updated docker to install v18 of Node as the repo uses v18.