### PR TITLE
Schema for assertionMethod public key

### DIFF
--- a/dsnp/index.ts
+++ b/dsnp/index.ts
@@ -46,7 +46,12 @@ type AvroDeploy = {
 export type Deploy = ParquetDeploy | AvroDeploy;
 
 export type ParquetSchemaName = "broadcast" | "profile" | "reaction" | "reply" | "tombstone" | "update";
-export type AvroSchemaName = "publicKey" | "userPublicFollows" | "userPrivateFollows" | "userPrivateConnections";
+export type AvroSchemaName =
+  | "publicKey_keyAgreement"
+  | "publicKey_assertionMethod"
+  | "userPublicFollows"
+  | "userPrivateFollows"
+  | "userPrivateConnections";
 
 export type SchemaName = ParquetSchemaName | AvroSchemaName;
 
@@ -108,7 +113,7 @@ export const schemas = new Map<SchemaName, Deploy>([
     },
   ],
   [
-    "publicKey",
+    "publicKey_keyAgreement",
     {
       model: publicKey,
       modelType: "AvroBinary",
@@ -141,6 +146,15 @@ export const schemas = new Map<SchemaName, Deploy>([
       modelType: "AvroBinary",
       payloadLocation: "Paginated",
       settings: [],
+    },
+  ],
+  [
+    "publicKey_assertionMethod",
+    {
+      model: publicKey,
+      modelType: "AvroBinary",
+      payloadLocation: "Itemized",
+      settings: ["AppendOnly", "SignatureRequired"],
     },
   ],
 ]);

--- a/dsnp/publicKey.ts
+++ b/dsnp/publicKey.ts
@@ -6,7 +6,8 @@ export default {
     // When converting from Frequency Data to DSNP Announcement, assume:
     // - announcementType = 7
     // - fromId = [Associated MSA Id]
-    // - keyType = 1 for this SchemaId
+    // - keyType = 1 for keyAgreement (used for graph encryption/decryption and PRIds), or
+    //   keyType = 2 for assertionMethod (used for credential signatures)
     // - keyId = `index` from the Itemized storage
     // DID Key Id could be publicKey or could be the index of the array. Not user assigned
     {


### PR DESCRIPTION
Adds a new Frequency schema for Public Key Announcement with keyType 2 (assertionMethod), which DSNP uses for off-chain signatures.

Internally to this code, the existing keyType 1 Public Key schema has been labeled publicKey_keyAgreement, and this one publicKey_assertionMethod. The data format is identical for these; the only difference in practice is that keyAgreement uses x25519, and assertionMethod uses ed25519.

The deployment script has been changed so that a caller receives back the set of schemas and their IDs in case this is immediately useful, for example for announcing a public key.