### PR TITLE
Update CI, docker base, and healthcheck

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -25,7 +25,7 @@ jobs:
 
       - name: Build and push dsnp/instant-seal-node-with-deployed-schemas
         id: docker_build_instant_seal_node_with_deployed_schemas
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           push: true
           file: Dockerfile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           registry-url: 'https://registry.npmjs.org'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Docker image for running Frequency parachain node container (with collating)
 # locally in instant seal mode then deploying schemas to that node.
 
-#This pulls the latest instant-seal-node image
-FROM frequencychain/instant-seal-node:latest as frequency-image
+#This pulls the latest standalone-node image
+FROM frequencychain/standalone-node:latest as frequency-image
 
 #Switch to root to install node on image
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ EXPOSE 9944
 VOLUME ["/data"]
 
 HEALTHCHECK --start-period=15s \
-  CMD curl --fail -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "rpc_methods"}' http://localhost:9944/ || exit 1
+  CMD curl --silent --fail -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "schemas_getBySchemaId", "params": [11]}' http://localhost:9944/ | grep -qv '{"jsonrpc":"2.0","result":null,"id":1}' || exit 1
 
 ENTRYPOINT ["/tini", "--"]
 

--- a/README.md
+++ b/README.md
@@ -153,18 +153,17 @@ There are 8 schemas on the connected chain.
 ## Use with Docker
 
 This repo deploys `dsnp/instant-seal-node-with-deployed-schemas` to Docker Hub.
-It is based on a [Frequency Standalone Docker](https://hub.docker.com/r/frequencychain/standalone-node) with the schemas automatically deployed on top of it.
+It is based on a [Frequency Standalone Docker](https://hub.docker.com/r/frequencychain/standalone-node) with the schemas automatically deployed on top of it with the image defaults including using "instant sealing" mode.
 
+Note: `--platform=linux/amd64` is because as `frequencychain` images are only published for the `linux/amd64` platform.
 
 ### Run Locally
 For any local testing do the following:
-1. `docker pull dsnp/instant-seal-node-with-deployed-schemas:latest`
-2. `docker run docker run --rm -p 9944:9944 dsnp/instant-seal-node-with-deployed-schemas:latest`
+1. `docker pull --platform=linux/amd64 dsnp/instant-seal-node-with-deployed-schemas:latest`
+2. `docker run  --platform=linux/amd64 --rm -p 9944:9944 dsnp/instant-seal-node-with-deployed-schemas:latest`
 
 ### Build Locally
-1. `docker build -t dsnp/instant-seal-node-with-deployed-schemas:latest -t dsnp/instant-seal-node-with-deployed-schemas:<versionNumberHere> .`
-
-Note: `--platform=linux/amd64` is required as `frequencychain` images are only published for the `linux/amd64` platform.
+1. `docker build --platform=linux/amd64 -t dsnp/instant-seal-node-with-deployed-schemas:latest -t dsnp/instant-seal-node-with-deployed-schemas:<versionNumberHere> .`
 
 ### Pushing Docker Image
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,8 @@ There are 8 schemas on the connected chain.
 
 ## Use with Docker
 
-This repo includes a docker image to push a [Frequency instant-seal-node](https://hub.docker.com/r/frequencychain/instant-seal-node) with the schemas deployed on top of it to docker hub under `dsnp/instant-seal-node-with-deployed-schemas`.
+This repo deploys `dsnp/instant-seal-node-with-deployed-schemas` to Docker Hub.
+It is based on a [Frequency Standalone Docker](https://hub.docker.com/r/frequencychain/standalone-node) with the schemas automatically deployed on top of it.
 
 
 ### Run Locally
@@ -162,6 +163,8 @@ For any local testing do the following:
 
 ### Build Locally
 1. `docker build -t dsnp/instant-seal-node-with-deployed-schemas:latest -t dsnp/instant-seal-node-with-deployed-schemas:<versionNumberHere> .`
+
+Note: `--platform=linux/amd64` is required as `frequencychain` images are only published for the `linux/amd64` platform.
 
 ### Pushing Docker Image
 

--- a/scripts/deploy_schemas_to_node.sh
+++ b/scripts/deploy_schemas_to_node.sh
@@ -7,17 +7,8 @@ npm --version
 ldd --version
 whoami
 
-/frequency/frequency --dev \
-    -lruntime=debug \
-    --sealing=instant \
-    --no-telemetry \
-    --no-prometheus \
-    --rpc-port=9944 \
-    --rpc-external \
-    --rpc-cors=all \
-    --rpc-methods=Unsafe \
-    --base-path=/data \
-    &
+# Base image start script
+/frequency/frequency-start.sh &
 
 cd frequency/schemas
 npm run deploy


### PR DESCRIPTION
Problem
=======
Needed to update the base docker base and make sure the health check was correct for loading the schemas instead of just that the rpc was available.

Solution
========
- Updated GitHub Action versions
- Updated health check to verify the existence of schema id 11
- Updated the docker base to use the newer `frequencychain/standalone-node` Closes #47