### PR TITLE
feat: re-work Docker image so that Frequency CLI options may be passed when instantiating a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,4 @@ VOLUME ["/data"]
 HEALTHCHECK --start-period=15s \
   CMD curl --silent --fail -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "schemas_getBySchemaId", "params": [11]}' http://localhost:9944/ | grep -qv '{"jsonrpc":"2.0","result":null,"id":1}' || exit 1
 
-ENTRYPOINT ["/tini", "--"]
-
-# Params which can be overriden from CLI
-CMD ["/bin/bash", "frequency/deploy_schemas_to_node.sh"]
+ENTRYPOINT ["/tini", "--", "frequency/deploy_schemas_to_node.sh"]

--- a/scripts/deploy_schemas_to_node.sh
+++ b/scripts/deploy_schemas_to_node.sh
@@ -8,7 +8,7 @@ ldd --version
 whoami
 
 # Base image start script
-/frequency/frequency-start.sh &
+/frequency/frequency-start.sh $* &
 
 cd frequency/schemas
 npm run deploy


### PR DESCRIPTION
This PR re-works the Docker container built by this repo so that additional CLI options can be passed to the Frequency node simply by adding them to the `CMD` (`command: ` in `docker-compose.yaml`).

Closes: #51 

Solution
========
* Removed `CMD` from Docker image; moved existing `CMD` & appended to `ENTRYPOINT` instead
* Allowed for CLI parameter pass-through in `deploy_schemas_to_node.sh` script

Double Checks:
---------------
- [] Did you update the changelog?
- [] Do you have good documentation on exported methods?

Steps to Verify:
----------------
1. Build a new Docker image from this repo
2. Start up a container & add CLI parameters using the CMD property
3. Inspect the running container & see if the parameters were honored