### PR TITLE
Remove references to the old Testnet on Rococo

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Will output various information about the schemas on the chain as well as attemp
 ├─────────┼─────────────────────┼────────────────────────────────────────────┤
 │    0    │    'endpointUrl'    │ 'wss://frequency-seal.liberti.social:9944' │
 │    1    │   'clientVersion'   │            '0.1.0-377bbe37fbe'             │
-│    2    │     'specName'      │             'frequency-rococo'             │
+│    2    │     'specName'      │             'frequency'                    │
 │    3    │    'specVersion'    │                    '1'                     │
 │    4    │ 'latestBlockNumber' │                    '16'                    │
 └─────────┴─────────────────────┴────────────────────────────────────────────┘

--- a/dsnp/index.ts
+++ b/dsnp/index.ts
@@ -196,23 +196,9 @@ export const getSchema = (name: SchemaName): Deploy | null => {
 export type SchemaMapping = { [schemaName: string]: { [version: string]: number } };
 const chainMapping: { [genesisHash: string]: SchemaMapping } = {};
 
-export const GENESIS_HASH_TESTNET_ROCOCO = "0x0c33dfffa907de5683ae21cc6b4af899b5c4de83f3794ed75b2dc74e1b088e72";
 export const GENESIS_HASH_TESTNET_PASEO = "0x203c6838fc78ea3660a2f298a58d859519c72a5efdc0f194abd6f0d5ce1838e0";
 export const GENESIS_HASH_MAINNET = "0x4a587bf17a404e3572747add7aab7bbe56e805a5479c6c436f07f36fcc8d3ae1";
 
-chainMapping[GENESIS_HASH_TESTNET_ROCOCO] = {
-  tombstone: { "1.2": 1 },
-  broadcast: { "1.2": 2 },
-  reply: { "1.2": 3 },
-  reaction: { "1.1": 4 },
-  profile: { "1.2": 5 },
-  update: { "1.2": 6 },
-  "public-key-key-agreement": { "1.2": 18 },
-  "public-follows": { "1.2": 13 },
-  "private-follows": { "1.2": 14 },
-  "private-connections": { "1.2": 15 },
-  "public-key-assertion-method": { "1.3": 100 },
-};
 chainMapping[GENESIS_HASH_TESTNET_PASEO] = {
   tombstone: { "1.2": 1 },
   broadcast: { "1.2": 2 },


### PR DESCRIPTION
Frequency testnet on Rococo is shut down, so remove references to it.