### PR TITLE
Remove dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ import { dsnp } from "@dsnp/frequency-schemas";
 import { ApiPromise } from "@polkadot/api";
 
 const api = ApiPromise.create(/* ... */);
-console.log(await dsnp.getSchemaId(api, "broadcast"));
+console.log(dsnp.getSchemaId("broadcast", "1.3", api.genesisHash.toString()));
 ```
 
 The API connection is used only to identify the chain by its genesis hash.
@@ -40,7 +40,7 @@ dsnp.setSchemaMapping(api.genesisHash.toString(), {
   // ...
 });
 
-console.log(await dsnp.getSchemaId(api, "broadcast")); // yields 67
+console.log(dsnp.getSchemaId("broadcast", "1.2", api.genesisHash.toString())); // yields 67
 ```
 
 ### With Parquet Writer

--- a/dsnp/index.ts
+++ b/dsnp/index.ts
@@ -1,5 +1,3 @@
-import { ApiPromise } from "@polkadot/api";
-
 import type { Schema } from "avsc";
 import { DSNPParquetSchema } from "@dsnp/schemas/types/dsnp-parquet.js";
 import {
@@ -283,19 +281,14 @@ chainMapping["default"] = {
 };
 
 /**
- * Gets the schemaId from the Frequency instance configured for
- * apiPromise for the given DSNP type and version. If version is
- * unspecified, the latest version is returned. (You probably only
- * need version if you're migrating.)
+ * Gets the schemaId for for given DSNP type and version and genesis hash.
+ * If version is unspecified, the latest version is returned. (You probably
+ * only need version if you're migrating.)
+ * If genesis hash is unspecified, the mainnet genesis hash and schema
+ * numbers will be used.
  */
-export const getSchemaId = async (
-  apiPromise: Promise<ApiPromise>,
-  schemaName: SchemaName,
-  dsnpVersion?: DSNPVersion,
-): Promise<number> => {
-  const api = await apiPromise;
-  const genesisHash = api.genesisHash.toString();
-  let mapping = chainMapping[genesisHash];
+export const getSchemaId = (schemaName: SchemaName, dsnpVersion?: DSNPVersion, genesisHash?: string): number => {
+  let mapping = chainMapping[genesisHash || GENESIS_HASH_MAINNET];
   // If we don't recognize this chain, use default mapping
   if (!mapping) mapping = chainMapping["default"];
   const versions = mapping[schemaName];

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@dsnp/schemas": "^1.3.1",
-        "@frequency-chain/api-augment": "^1.13.1",
-        "@polkadot/api": "^13.0.1",
-        "@polkadot/util": "^13.1.1",
         "json-stringify-pretty-compact": "^4.0.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.3.3"
@@ -20,7 +17,9 @@
       "devDependencies": {
         "@dsnp/parquetjs": "^1.3.5",
         "@dsnp/test-generators": "^0.1.0",
-        "@polkadot/types": "^13.0.1",
+        "@frequency-chain/api-augment": "^1.13.2",
+        "@polkadot/api": "^13.2.1",
+        "@polkadot/types": "^13.2.1",
         "@types/jest": "^29.5.11",
         "@typescript-eslint/eslint-plugin": "^6.17.0",
         "@typescript-eslint/parser": "^6.17.0",
@@ -853,13 +852,14 @@
       }
     },
     "node_modules/@frequency-chain/api-augment": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@frequency-chain/api-augment/-/api-augment-1.13.1.tgz",
-      "integrity": "sha512-MeJF2p0EoMnb3ABfSZ6PRNBpGOQviGN9SgWdb3bysNA8zhuA+BCzjh+lNHnbJQUDeU9mlHO/XKy3pqL300EDZg==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@frequency-chain/api-augment/-/api-augment-1.13.2.tgz",
+      "integrity": "sha512-XU6JKk1QWnMYU5s8SFLClLiYhQ9VtKGVdBe9rBpguAZM37YxygfSPUUVrywaGBTb7iMfL1Lxyb+B1m7c+EqPJg==",
+      "dev": true,
       "dependencies": {
-        "@polkadot/api": "^13.0.1",
-        "@polkadot/rpc-provider": "^13.0.1",
-        "@polkadot/types": "^13.0.1",
+        "@polkadot/api": "^13.2.1",
+        "@polkadot/rpc-provider": "^13.2.1",
+        "@polkadot/types": "^13.2.1",
         "globals": "^15.9.0"
       }
     },
@@ -867,6 +867,7 @@
       "version": "15.9.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-15.9.0.tgz",
       "integrity": "sha512-SmSKyLLKFbSr6rptvP8izbyxJL4ILwqO9Jg23UA0sDlGlu58V59D1//I3vlc0KJphVdUR7vMjHIplYnzBxorQA==",
+      "dev": true,
       "engines": {
         "node": ">=18"
       },
@@ -1365,6 +1366,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.3.0.tgz",
       "integrity": "sha512-t01iSXPuN+Eqzb4eBX0S5oubSqXbK/xXa1Ne18Hj8f9pStxztHCE2gfboSp/dZRLSqfuLpRK2nDXDK+W9puocA==",
+      "dev": true,
       "dependencies": {
         "@noble/hashes": "1.3.3"
       },
@@ -1376,6 +1378,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
       "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
+      "dev": true,
       "engines": {
         "node": ">= 16"
       },
@@ -1434,18 +1437,21 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/@polkadot-api/json-rpc-provider/-/json-rpc-provider-0.0.1.tgz",
       "integrity": "sha512-/SMC/l7foRjpykLTUTacIH05H3mr9ip8b5xxfwXlVezXrNVLp3Cv0GX6uItkKd+ZjzVPf3PFrDF2B2/HLSNESA==",
+      "dev": true,
       "optional": true
     },
     "node_modules/@polkadot-api/json-rpc-provider-proxy": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@polkadot-api/json-rpc-provider-proxy/-/json-rpc-provider-proxy-0.1.0.tgz",
       "integrity": "sha512-8GSFE5+EF73MCuLQm8tjrbCqlgclcHBSRaswvXziJ0ZW7iw3UEMsKkkKvELayWyBuOPa2T5i1nj6gFOeIsqvrg==",
+      "dev": true,
       "optional": true
     },
     "node_modules/@polkadot-api/metadata-builders": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@polkadot-api/metadata-builders/-/metadata-builders-0.3.2.tgz",
       "integrity": "sha512-TKpfoT6vTb+513KDzMBTfCb/ORdgRnsS3TDFpOhAhZ08ikvK+hjHMt5plPiAX/OWkm1Wc9I3+K6W0hX5Ab7MVg==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "@polkadot-api/substrate-bindings": "0.6.0",
@@ -1456,6 +1462,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@polkadot-api/observable-client/-/observable-client-0.3.2.tgz",
       "integrity": "sha512-HGgqWgEutVyOBXoGOPp4+IAq6CNdK/3MfQJmhCJb8YaJiaK4W6aRGrdQuQSTPHfERHCARt9BrOmEvTXAT257Ug==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "@polkadot-api/metadata-builders": "0.3.2",
@@ -1471,6 +1478,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-bindings/-/substrate-bindings-0.6.0.tgz",
       "integrity": "sha512-lGuhE74NA1/PqdN7fKFdE5C1gNYX357j1tWzdlPXI0kQ7h3kN0zfxNOpPUN7dIrPcOFZ6C0tRRVrBylXkI6xPw==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "@noble/hashes": "^1.3.1",
@@ -1483,6 +1491,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/@polkadot-api/substrate-client/-/substrate-client-0.1.4.tgz",
       "integrity": "sha512-MljrPobN0ZWTpn++da9vOvt+Ex+NlqTlr/XT7zi9sqPtDJiQcYl+d29hFAgpaeTqbeQKZwz3WDE9xcEfLE8c5A==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "@polkadot-api/json-rpc-provider": "0.0.1",
@@ -1493,25 +1502,27 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@polkadot-api/utils/-/utils-0.1.0.tgz",
       "integrity": "sha512-MXzWZeuGxKizPx2Xf/47wx9sr/uxKw39bVJUptTJdsaQn/TGq+z310mHzf1RCGvC1diHM8f593KrnDgc9oNbJA==",
+      "dev": true,
       "optional": true
     },
     "node_modules/@polkadot/api": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-13.1.1.tgz",
-      "integrity": "sha512-s4BTMKcf/3YoU14C0GmRC9APQTilNR/kNprRrfP1S+6umwsNoSuFXSZhaUWUovVlNWw7v7dca8NbFDSTjkoS4w==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api/-/api-13.2.1.tgz",
+      "integrity": "sha512-QvgKD3/q6KIU3ZuNYFJUNc6B8bGBoqeMF+iaPxJn3Twhh4iVD5XIymD5fVszSqiL1uPXMhzcWecjwE8rDidBoQ==",
+      "dev": true,
       "dependencies": {
-        "@polkadot/api-augment": "13.1.1",
-        "@polkadot/api-base": "13.1.1",
-        "@polkadot/api-derive": "13.1.1",
+        "@polkadot/api-augment": "13.2.1",
+        "@polkadot/api-base": "13.2.1",
+        "@polkadot/api-derive": "13.2.1",
         "@polkadot/keyring": "^13.1.1",
-        "@polkadot/rpc-augment": "13.1.1",
-        "@polkadot/rpc-core": "13.1.1",
-        "@polkadot/rpc-provider": "13.1.1",
-        "@polkadot/types": "13.1.1",
-        "@polkadot/types-augment": "13.1.1",
-        "@polkadot/types-codec": "13.1.1",
-        "@polkadot/types-create": "13.1.1",
-        "@polkadot/types-known": "13.1.1",
+        "@polkadot/rpc-augment": "13.2.1",
+        "@polkadot/rpc-core": "13.2.1",
+        "@polkadot/rpc-provider": "13.2.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-augment": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
+        "@polkadot/types-create": "13.2.1",
+        "@polkadot/types-known": "13.2.1",
         "@polkadot/util": "^13.1.1",
         "@polkadot/util-crypto": "^13.1.1",
         "eventemitter3": "^5.0.1",
@@ -1523,15 +1534,16 @@
       }
     },
     "node_modules/@polkadot/api-augment": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-13.1.1.tgz",
-      "integrity": "sha512-QWqw2zWpEEyP2s220b6rv0iq44XwhqQabicpGzCeMPAEJOnvzGjZMVD95o2C3oOq1FR025wQ1CU+4la2P4djNw==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-augment/-/api-augment-13.2.1.tgz",
+      "integrity": "sha512-NTkI+/Hm48eWc/4Ojh/5elxnjnow5ptXK97IZdkWAe7mWi9hJR05Uq5lGt/T/57E9LSRWEuYje8cIDS3jbbAAw==",
+      "dev": true,
       "dependencies": {
-        "@polkadot/api-base": "13.1.1",
-        "@polkadot/rpc-augment": "13.1.1",
-        "@polkadot/types": "13.1.1",
-        "@polkadot/types-augment": "13.1.1",
-        "@polkadot/types-codec": "13.1.1",
+        "@polkadot/api-base": "13.2.1",
+        "@polkadot/rpc-augment": "13.2.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-augment": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
         "@polkadot/util": "^13.1.1",
         "tslib": "^2.7.0"
       },
@@ -1540,12 +1552,13 @@
       }
     },
     "node_modules/@polkadot/api-base": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-13.1.1.tgz",
-      "integrity": "sha512-VEIOit6oTkOUi3CRUD1c6b/QF3cP0J1XxyMJR5q1/58fgTeUBjREmIyDgZzoXNX5ZK/9VD6pzqoWnKMeJGV5dA==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-base/-/api-base-13.2.1.tgz",
+      "integrity": "sha512-00twdIjTjzdYNdU19i2YKLoWBmf2Yr6b3qrvqIVScHipUkKMbfFBgoPRB5FtcviBbEvLurgfyzHklwnrbWo8GQ==",
+      "dev": true,
       "dependencies": {
-        "@polkadot/rpc-core": "13.1.1",
-        "@polkadot/types": "13.1.1",
+        "@polkadot/rpc-core": "13.2.1",
+        "@polkadot/types": "13.2.1",
         "@polkadot/util": "^13.1.1",
         "rxjs": "^7.8.1",
         "tslib": "^2.7.0"
@@ -1555,16 +1568,17 @@
       }
     },
     "node_modules/@polkadot/api-derive": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-13.1.1.tgz",
-      "integrity": "sha512-Avj4iSZlXXAPEhwnVAA0ZczW1HsgYYIpJFeC6Em3FhpDl4GLxS/UqwpGRhr97Ibqj6Ukv0dJ755xljyXkXiP+A==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/api-derive/-/api-derive-13.2.1.tgz",
+      "integrity": "sha512-npxvS0kYcSFqmYv2G8QKWAJwFhIv/MBuGU0bV7cGP9K1A3j2Do3yYjvN1dTtY20jBavWNwmWFdXBV6/TRRsgmg==",
+      "dev": true,
       "dependencies": {
-        "@polkadot/api": "13.1.1",
-        "@polkadot/api-augment": "13.1.1",
-        "@polkadot/api-base": "13.1.1",
-        "@polkadot/rpc-core": "13.1.1",
-        "@polkadot/types": "13.1.1",
-        "@polkadot/types-codec": "13.1.1",
+        "@polkadot/api": "13.2.1",
+        "@polkadot/api-augment": "13.2.1",
+        "@polkadot/api-base": "13.2.1",
+        "@polkadot/rpc-core": "13.2.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
         "@polkadot/util": "^13.1.1",
         "@polkadot/util-crypto": "^13.1.1",
         "rxjs": "^7.8.1",
@@ -1578,6 +1592,7 @@
       "version": "13.1.1",
       "resolved": "https://registry.npmjs.org/@polkadot/keyring/-/keyring-13.1.1.tgz",
       "integrity": "sha512-Wm+9gn946GIPjGzvueObLGBBS9s541HE6mvKdWGEmPFMzH93ESN931RZlOd67my5MWryiSP05h5SHTp7bSaQTA==",
+      "dev": true,
       "dependencies": {
         "@polkadot/util": "13.1.1",
         "@polkadot/util-crypto": "13.1.1",
@@ -1595,6 +1610,7 @@
       "version": "13.1.1",
       "resolved": "https://registry.npmjs.org/@polkadot/networks/-/networks-13.1.1.tgz",
       "integrity": "sha512-eEQ4+Mfl1xFtApeU5PdXZ2XBhxNSvUz9yW+YQVGUCkXRjWFbqNRsTOYWGd9uFbiAOXiiiXbtqfZpxSDzIm4XOg==",
+      "dev": true,
       "dependencies": {
         "@polkadot/util": "13.1.1",
         "@substrate/ss58-registry": "^1.50.0",
@@ -1605,13 +1621,14 @@
       }
     },
     "node_modules/@polkadot/rpc-augment": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-13.1.1.tgz",
-      "integrity": "sha512-RXcYT+pPkwmAPTpH7DcIjaVEOEzdkAXJBjfF0OxbFKWcqJb8uwRK5PNr7m9OhymwblNFuzmAaLH7bWdzzKiOOA==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-augment/-/rpc-augment-13.2.1.tgz",
+      "integrity": "sha512-HkndaAJPR1fi2xrzvP3q4g48WUCb26btGTeg1AKG9FGx9P2dgtpaPRmbMitmgVSzzRurrkxf3Meip8nC7BwDeg==",
+      "dev": true,
       "dependencies": {
-        "@polkadot/rpc-core": "13.1.1",
-        "@polkadot/types": "13.1.1",
-        "@polkadot/types-codec": "13.1.1",
+        "@polkadot/rpc-core": "13.2.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
         "@polkadot/util": "^13.1.1",
         "tslib": "^2.7.0"
       },
@@ -1620,13 +1637,14 @@
       }
     },
     "node_modules/@polkadot/rpc-core": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-13.1.1.tgz",
-      "integrity": "sha512-dxb1PFCzP9A8go/20KO+nNiqYMjsjY2gU/w0iPyLVH64yI9CW8GWd+77oEmcAuHKMPEHgpfa6sGuR/r0z+M5SQ==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-core/-/rpc-core-13.2.1.tgz",
+      "integrity": "sha512-hy0GksUlb/TfQ38m3ysIWj3qD+rIsyCdxx8Ug5rIx1u0odv86NZ7nTqtH066Ct2riVaPBgBkObFnlpDWTJ6auA==",
+      "dev": true,
       "dependencies": {
-        "@polkadot/rpc-augment": "13.1.1",
-        "@polkadot/rpc-provider": "13.1.1",
-        "@polkadot/types": "13.1.1",
+        "@polkadot/rpc-augment": "13.2.1",
+        "@polkadot/rpc-provider": "13.2.1",
+        "@polkadot/types": "13.2.1",
         "@polkadot/util": "^13.1.1",
         "rxjs": "^7.8.1",
         "tslib": "^2.7.0"
@@ -1636,13 +1654,14 @@
       }
     },
     "node_modules/@polkadot/rpc-provider": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-13.1.1.tgz",
-      "integrity": "sha512-9tG8fEZWsxCoF6PKGECIQHp2tORKt6yIESSdg3pWSP/4xzBEQulqn0SKHcOZV/wwY8goSmw14dA0iyJdLFRP5g==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/rpc-provider/-/rpc-provider-13.2.1.tgz",
+      "integrity": "sha512-bbMVYHTNFUa89aY3UQ1hFYD+dP+v+0vhjsnHYYlv37rSUTqOGqW91rkHd63xYCpLAimFt7KRw8xR+SMSYiuDjw==",
+      "dev": true,
       "dependencies": {
         "@polkadot/keyring": "^13.1.1",
-        "@polkadot/types": "13.1.1",
-        "@polkadot/types-support": "13.1.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-support": "13.2.1",
         "@polkadot/util": "^13.1.1",
         "@polkadot/util-crypto": "^13.1.1",
         "@polkadot/x-fetch": "^13.1.1",
@@ -1661,14 +1680,15 @@
       }
     },
     "node_modules/@polkadot/types": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-13.1.1.tgz",
-      "integrity": "sha512-ijNlMGgoUtPtjZCzBHqPJXd9PGwE+kKy7qzQ/Xav4RAMD8X/Mo+9okam755J9WNHCOcajVIQo0PDYeZzLYVk1Q==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types/-/types-13.2.1.tgz",
+      "integrity": "sha512-5yQ0mHMNvwgXeHQ1RZOuHaeak3utAdcBqCpHoagnYrAnGHqtO7kg7YLtT4LkFw2nwL85axu8tOQMv6/3kpFy9w==",
+      "dev": true,
       "dependencies": {
         "@polkadot/keyring": "^13.1.1",
-        "@polkadot/types-augment": "13.1.1",
-        "@polkadot/types-codec": "13.1.1",
-        "@polkadot/types-create": "13.1.1",
+        "@polkadot/types-augment": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
+        "@polkadot/types-create": "13.2.1",
         "@polkadot/util": "^13.1.1",
         "@polkadot/util-crypto": "^13.1.1",
         "rxjs": "^7.8.1",
@@ -1679,12 +1699,13 @@
       }
     },
     "node_modules/@polkadot/types-augment": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-13.1.1.tgz",
-      "integrity": "sha512-ltsznxCNJR/RKMEbBgwAC9VgbJBYT08MltDiZKOnjJD+Uk2RnOkTpnV/rOCd6MxQ1TNQV/KBCvWT2Y0pK5Gw0Q==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-augment/-/types-augment-13.2.1.tgz",
+      "integrity": "sha512-FpV7/2kIJmmswRmwUbp41lixdNX15olueUjHnSweFk0xEn2Ur43oC0Y3eU3Ab7Y5gPJpceMCfwYz+PjCUGedDA==",
+      "dev": true,
       "dependencies": {
-        "@polkadot/types": "13.1.1",
-        "@polkadot/types-codec": "13.1.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
         "@polkadot/util": "^13.1.1",
         "tslib": "^2.7.0"
       },
@@ -1693,9 +1714,10 @@
       }
     },
     "node_modules/@polkadot/types-codec": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-13.1.1.tgz",
-      "integrity": "sha512-sSvtUtP7YxhlKjN0HIFWIlDUsAxQbJqnAGmFadx4FT6jjHpKSyxi1bBVI5fJqlYVereHkFWhPYX044DIjZnk7w==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-codec/-/types-codec-13.2.1.tgz",
+      "integrity": "sha512-tFAzzS8sMYItoD5a91sFMD+rskWyv4WjSmUZaj0Y4OfLtDAiQvgO0KncdGJIB6D+zZ/T7khpgsv/CZbN3YnezA==",
+      "dev": true,
       "dependencies": {
         "@polkadot/util": "^13.1.1",
         "@polkadot/x-bigint": "^13.1.1",
@@ -1706,11 +1728,12 @@
       }
     },
     "node_modules/@polkadot/types-create": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-13.1.1.tgz",
-      "integrity": "sha512-l3LBsMKtx6tYtqxY3IiBEfKtcRacyaKo9YWnh8QDtXlMwBgs+2KJj8sA8/y2OHOSiKYiffz8M/B7KHL7pF5s3Q==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-create/-/types-create-13.2.1.tgz",
+      "integrity": "sha512-O/WKdsrNuMaZLf+XRCdum2xJYs5OKC6N3EMPF5Uhg10b80Y/hQCbzA/iWd3/aMNDLUA5XWhixwzJdrZWIMVIzg==",
+      "dev": true,
       "dependencies": {
-        "@polkadot/types-codec": "13.1.1",
+        "@polkadot/types-codec": "13.2.1",
         "@polkadot/util": "^13.1.1",
         "tslib": "^2.7.0"
       },
@@ -1719,14 +1742,15 @@
       }
     },
     "node_modules/@polkadot/types-known": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-13.1.1.tgz",
-      "integrity": "sha512-VY7WbcAhaadNarQXC8TaP+M262a+79091dAU1KYYTHxzCndC72ly0rSA+pZZ4bVloKdHrq6Xh3paAISSoEDXhg==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-known/-/types-known-13.2.1.tgz",
+      "integrity": "sha512-uz3c4/IvspLpgN8q15A+QH8KWFauzcrV3RfLFlMP2BkkF5qpOwNeP7c4U8j0CZGQySqBsJRCGWmgBXrXg669KA==",
+      "dev": true,
       "dependencies": {
         "@polkadot/networks": "^13.1.1",
-        "@polkadot/types": "13.1.1",
-        "@polkadot/types-codec": "13.1.1",
-        "@polkadot/types-create": "13.1.1",
+        "@polkadot/types": "13.2.1",
+        "@polkadot/types-codec": "13.2.1",
+        "@polkadot/types-create": "13.2.1",
         "@polkadot/util": "^13.1.1",
         "tslib": "^2.7.0"
       },
@@ -1735,9 +1759,10 @@
       }
     },
     "node_modules/@polkadot/types-support": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-13.1.1.tgz",
-      "integrity": "sha512-Xjj25175i4X39N37polUxZqtlloa5G5eizEbzk4qKvFdWuvPe6pOVS63oS7WzMhGbZi2PecThDFRz+GptcHqXQ==",
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/@polkadot/types-support/-/types-support-13.2.1.tgz",
+      "integrity": "sha512-jSbbUTXU+yZJQPRAWmxaDoe4NRO6SjpZPzBIbpuiadx1slON8XB80fVYIGBXuM2xRVrNrB6fCjyCTG7Razj6Hg==",
+      "dev": true,
       "dependencies": {
         "@polkadot/util": "^13.1.1",
         "tslib": "^2.7.0"
@@ -1750,6 +1775,7 @@
       "version": "13.1.1",
       "resolved": "https://registry.npmjs.org/@polkadot/util/-/util-13.1.1.tgz",
       "integrity": "sha512-M4iQ5Um8tFdDmD7a96nPzfrEt+kxyWOqQDPqXyaax4QBnq/WCbq0jo8IO61uz55mdMQnGZvq8jd8uge4V6JzzQ==",
+      "dev": true,
       "dependencies": {
         "@polkadot/x-bigint": "13.1.1",
         "@polkadot/x-global": "13.1.1",
@@ -1767,6 +1793,7 @@
       "version": "13.1.1",
       "resolved": "https://registry.npmjs.org/@polkadot/util-crypto/-/util-crypto-13.1.1.tgz",
       "integrity": "sha512-FG68rrLPdfLcscEyH10vnGkakM4O2lqr71S3GDhgc9WXaS8y9jisLgMPg8jbMHiQBJ3iKYkmtPKiLBowRslj2w==",
+      "dev": true,
       "dependencies": {
         "@noble/curves": "^1.3.0",
         "@noble/hashes": "^1.3.3",
@@ -1790,6 +1817,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-7.3.2.tgz",
       "integrity": "sha512-AJEXChcf/nKXd5Q/YLEV5dXQMle3UNT7jcXYmIffZAo/KI394a+/24PaISyQjoNC0fkzS1Q8T5pnGGHmXiVz2g==",
+      "dev": true,
       "dependencies": {
         "@polkadot/wasm-util": "7.3.2",
         "tslib": "^2.6.2"
@@ -1806,6 +1834,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto/-/wasm-crypto-7.3.2.tgz",
       "integrity": "sha512-+neIDLSJ6jjVXsjyZ5oLSv16oIpwp+PxFqTUaZdZDoA2EyFRQB8pP7+qLsMNk+WJuhuJ4qXil/7XiOnZYZ+wxw==",
+      "dev": true,
       "dependencies": {
         "@polkadot/wasm-bridge": "7.3.2",
         "@polkadot/wasm-crypto-asmjs": "7.3.2",
@@ -1826,6 +1855,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-7.3.2.tgz",
       "integrity": "sha512-QP5eiUqUFur/2UoF2KKKYJcesc71fXhQFLT3D4ZjG28Mfk2ZPI0QNRUfpcxVQmIUpV5USHg4geCBNuCYsMm20Q==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -1840,6 +1870,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-init/-/wasm-crypto-init-7.3.2.tgz",
       "integrity": "sha512-FPq73zGmvZtnuJaFV44brze3Lkrki3b4PebxCy9Fplw8nTmisKo9Xxtfew08r0njyYh+uiJRAxPCXadkC9sc8g==",
+      "dev": true,
       "dependencies": {
         "@polkadot/wasm-bridge": "7.3.2",
         "@polkadot/wasm-crypto-asmjs": "7.3.2",
@@ -1859,6 +1890,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-7.3.2.tgz",
       "integrity": "sha512-15wd0EMv9IXs5Abp1ZKpKKAVyZPhATIAHfKsyoWCEFDLSOA0/K0QGOxzrAlsrdUkiKZOq7uzSIgIDgW8okx2Mw==",
+      "dev": true,
       "dependencies": {
         "@polkadot/wasm-util": "7.3.2",
         "tslib": "^2.6.2"
@@ -1874,6 +1906,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@polkadot/wasm-util/-/wasm-util-7.3.2.tgz",
       "integrity": "sha512-bmD+Dxo1lTZyZNxbyPE380wd82QsX+43mgCm40boyKrRppXEyQmWT98v/Poc7chLuskYb6X8IQ6lvvK2bGR4Tg==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -1888,6 +1921,7 @@
       "version": "13.1.1",
       "resolved": "https://registry.npmjs.org/@polkadot/x-bigint/-/x-bigint-13.1.1.tgz",
       "integrity": "sha512-Cq4Y6fd9UWtRBZz8RX2tWEBL1IFwUtY6cL8p6HC9yhZtUR6OPjKZe6RIZQa9gSOoIuqZWd6PmtvSNGVH32yfkQ==",
+      "dev": true,
       "dependencies": {
         "@polkadot/x-global": "13.1.1",
         "tslib": "^2.7.0"
@@ -1900,6 +1934,7 @@
       "version": "13.1.1",
       "resolved": "https://registry.npmjs.org/@polkadot/x-fetch/-/x-fetch-13.1.1.tgz",
       "integrity": "sha512-qA6mIUUebJbS+oWzq/EagZflmaoa9b25WvsxSFn7mCvzKngXzr+GYCY4XiDwKY/S+/pr/kvSCKZ1ia8BDqPBYQ==",
+      "dev": true,
       "dependencies": {
         "@polkadot/x-global": "13.1.1",
         "node-fetch": "^3.3.2",
@@ -1913,6 +1948,7 @@
       "version": "13.1.1",
       "resolved": "https://registry.npmjs.org/@polkadot/x-global/-/x-global-13.1.1.tgz",
       "integrity": "sha512-DViIMmmEs29Qlsp058VTg2Mn7e3/CpGazNnKJrsBa0o1Ptxl13/4Z0fjqCpNi2GB+kaOsnREzxUORrHcU+PqcQ==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.7.0"
       },
@@ -1924,6 +1960,7 @@
       "version": "13.1.1",
       "resolved": "https://registry.npmjs.org/@polkadot/x-randomvalues/-/x-randomvalues-13.1.1.tgz",
       "integrity": "sha512-cXj4omwbgzQQSiBtV1ZBw+XhJUU3iz/DS6ghUnGllSZEK+fGqiyaNgeFQzDY0tKjm6kYaDpvtOHR3mHsbzDuTg==",
+      "dev": true,
       "dependencies": {
         "@polkadot/x-global": "13.1.1",
         "tslib": "^2.7.0"
@@ -1940,6 +1977,7 @@
       "version": "13.1.1",
       "resolved": "https://registry.npmjs.org/@polkadot/x-textdecoder/-/x-textdecoder-13.1.1.tgz",
       "integrity": "sha512-LpZ9KYc6HdBH+i86bCmun4g4GWMiWN/1Pzs0hNdanlQMfqp3UGzl1Dqp0nozMvjWAlvyG7ip235VgNMd8HEbqg==",
+      "dev": true,
       "dependencies": {
         "@polkadot/x-global": "13.1.1",
         "tslib": "^2.7.0"
@@ -1952,6 +1990,7 @@
       "version": "13.1.1",
       "resolved": "https://registry.npmjs.org/@polkadot/x-textencoder/-/x-textencoder-13.1.1.tgz",
       "integrity": "sha512-w1mT15B9ptN5CJNgN/A0CmBqD5y9OePjBdU6gmAd8KRhwXCF0MTBKcEZk1dHhXiXtX+28ULJWLrfefC5gxy69Q==",
+      "dev": true,
       "dependencies": {
         "@polkadot/x-global": "13.1.1",
         "tslib": "^2.7.0"
@@ -1964,6 +2003,7 @@
       "version": "13.1.1",
       "resolved": "https://registry.npmjs.org/@polkadot/x-ws/-/x-ws-13.1.1.tgz",
       "integrity": "sha512-E/xFmJTiFzu+IK5M3/8W/9fnvNJFelcnunPv/IgO6UST94SDaTsN/Gbeb6SqPb6CsrTHRl3WD+AZ3ErGGwQfEA==",
+      "dev": true,
       "dependencies": {
         "@polkadot/x-global": "13.1.1",
         "tslib": "^2.7.0",
@@ -1977,6 +2017,7 @@
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
       "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
+      "dev": true,
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -2010,6 +2051,7 @@
       "resolved": "https://registry.npmjs.org/@substrate/connect/-/connect-0.8.11.tgz",
       "integrity": "sha512-ofLs1PAO9AtDdPbdyTYj217Pe+lBfTLltdHDs3ds8no0BseoLeAGxpz1mHfi7zB4IxI3YyAiLjH6U8cw4pj4Nw==",
       "deprecated": "versions below 1.x are no longer maintained",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "@substrate/connect-extension-protocol": "^2.0.0",
@@ -2022,18 +2064,21 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@substrate/connect-extension-protocol/-/connect-extension-protocol-2.1.0.tgz",
       "integrity": "sha512-Wz5Cbn6S6P4vWfHyrsnPW7g15IAViMaXCk+jYkq4nNEMmzPtTKIEbtxrdDMBKrouOFtYKKp0znx5mh9KTCNqlA==",
+      "dev": true,
       "optional": true
     },
     "node_modules/@substrate/connect-known-chains": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@substrate/connect-known-chains/-/connect-known-chains-1.4.1.tgz",
       "integrity": "sha512-WlFKGEE3naIa7iTyy7hJ0RV0dyGpP7Zic1Z8sXr4bJmSEzZoHcfLRbM1D3T+zFAaitffVCu6k55Vj+CFzMPw1Q==",
+      "dev": true,
       "optional": true
     },
     "node_modules/@substrate/light-client-extension-helpers": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@substrate/light-client-extension-helpers/-/light-client-extension-helpers-1.0.0.tgz",
       "integrity": "sha512-TdKlni1mBBZptOaeVrKnusMg/UBpWUORNDv5fdCaJklP4RJiFOzBCrzC+CyVI5kQzsXBisZ+2pXm+rIjS38kHg==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "@polkadot-api/json-rpc-provider": "^0.0.1",
@@ -2051,7 +2096,8 @@
     "node_modules/@substrate/ss58-registry": {
       "version": "1.50.0",
       "resolved": "https://registry.npmjs.org/@substrate/ss58-registry/-/ss58-registry-1.50.0.tgz",
-      "integrity": "sha512-mkmlMlcC+MSd9rA+PN8ljGAm5fVZskvVwkXIsbx4NFwaT8kt38r7e9cyDWscG3z2Zn40POviZvEMrJSk+r2SgQ=="
+      "integrity": "sha512-mkmlMlcC+MSd9rA+PN8ljGAm5fVZskvVwkXIsbx4NFwaT8kt38r7e9cyDWscG3z2Zn40POviZvEMrJSk+r2SgQ==",
+      "dev": true
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
@@ -2127,6 +2173,7 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.5.tgz",
       "integrity": "sha512-V46N0zwKRF5Q00AZ6hWtN0T8gGmDUaUzLWQvHFo5yThtVwK/VCenFY3wXVbOvNfajEpsTfQM4IN9k/d6gUVX3A==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -2917,7 +2964,8 @@
     "node_modules/bn.js": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
+      "dev": true
     },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
@@ -3060,6 +3108,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.8.tgz",
       "integrity": "sha512-4T53u4PdgsXqKaIctwF8ifXlRTTmEPJ8iEPWFdGZvcf7sbwYo6FKFEX9eNNAnzFZ7EzJAQ3CJeOtCRA4rDp7Pw==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "peer": true,
@@ -3359,6 +3408,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
       "engines": {
         "node": ">= 12"
       }
@@ -3381,6 +3431,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -4209,7 +4260,8 @@
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "dev": true
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -4333,6 +4385,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
       "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4438,6 +4491,7 @@
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
       "dependencies": {
         "fetch-blob": "^3.1.2"
       },
@@ -6005,7 +6059,8 @@
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -6222,6 +6277,7 @@
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.3.1.tgz",
       "integrity": "sha512-qxBgB7Qa2sEQgHFjj0dSigq7fX4k6Saisd5Nelwp2q8mlbAFh5dHV9JTTlF8viYJLSSWgMCZFUom8PJcMNBoJw==",
+      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -6229,7 +6285,8 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -6238,9 +6295,10 @@
       "dev": true
     },
     "node_modules/nock": {
-      "version": "13.5.4",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.4.tgz",
-      "integrity": "sha512-yAyTfdeNJGGBFxWdzSKCBYxs5FxLbCg5X5Q4ets974hcQzG1+qCxvIyOo4j2Ry6MUlhWVMX4OoYDefAIIwupjw==",
+      "version": "13.5.5",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.5.tgz",
+      "integrity": "sha512-XKYnqUrCwXC8DGG1xX4YH5yNIrlh9c065uaMZZHUoeUUINTOyt+x/G+ezYk0Ft6ExSREVIs+qBJDK503viTfFA==",
+      "dev": true,
       "dependencies": {
         "debug": "^4.1.0",
         "json-stringify-safe": "^5.0.1",
@@ -6254,6 +6312,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6272,6 +6331,7 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
       "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -6289,6 +6349,7 @@
       "version": "4.7.1",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.7.1.tgz",
       "integrity": "sha512-wTSrZ+8lsRRa3I3H8Xr65dLWSgCvY2l4AOnaeKdPA9TB/WYMPaTcrzf3rXvFoVvjKNVnu0CcWSx54qq9GKRUYg==",
+      "dev": true,
       "optional": true,
       "peer": true,
       "bin": {
@@ -6752,6 +6813,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
       "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -6969,6 +7031,7 @@
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -7027,6 +7090,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/scale-ts/-/scale-ts-1.6.0.tgz",
       "integrity": "sha512-Ja5VCjNZR8TGKhUumy9clVVxcDpM+YFjAnkMuwQy68Hixio3VRRvWdE3g8T/yC+HXA0ZDQl2TGyUmtmbcVl40Q==",
+      "dev": true,
       "optional": true
     },
     "node_modules/semver": {
@@ -7151,6 +7215,7 @@
       "version": "2.0.26",
       "resolved": "https://registry.npmjs.org/smoldot/-/smoldot-2.0.26.tgz",
       "integrity": "sha512-F+qYmH4z2s2FK+CxGj8moYcd1ekSIKH8ywkdqlOz88Dat35iB1DIYL11aILN46YSGMzQW/lbJNS307zBSDN5Ig==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "ws": "^8.8.1"
@@ -7622,7 +7687,8 @@
     "node_modules/tslib": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "dev": true
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -7843,6 +7909,7 @@
       "version": "5.0.10",
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
       "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "peer": true,
@@ -7909,6 +7976,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -8046,6 +8114,7 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "devOptional": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -18,19 +18,16 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/LibertyDSNP/schemas.git"
+    "url": "git+https://github.com/LibertyDSNP/frequency-schemas.git"
   },
   "author": "DSNP.org",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/LibertyDSNP/schemas/issues"
+    "url": "https://github.com/LibertyDSNP/frequency-schemas/issues"
   },
-  "homepage": "https://github.com/LibertyDSNP/schemas#readme",
+  "homepage": "https://github.com/LibertyDSNP/frequency-schemas#readme",
   "dependencies": {
     "@dsnp/schemas": "^1.3.1",
-    "@frequency-chain/api-augment": "^1.13.1",
-    "@polkadot/api": "^13.0.1",
-    "@polkadot/util": "^13.1.1",
     "json-stringify-pretty-compact": "^4.0.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.3.3"
@@ -41,7 +38,9 @@
   "devDependencies": {
     "@dsnp/parquetjs": "^1.3.5",
     "@dsnp/test-generators": "^0.1.0",
-    "@polkadot/types": "^13.0.1",
+    "@frequency-chain/api-augment": "^1.13.2",
+    "@polkadot/api": "^13.2.1",
+    "@polkadot/types": "^13.2.1",
     "@types/jest": "^29.5.11",
     "@typescript-eslint/eslint-plugin": "^6.17.0",
     "@typescript-eslint/parser": "^6.17.0",


### PR DESCRIPTION
Reduced the non-dev dependencies by changing `getSchemaId` to take the genesis hash instead of an `ApiPromise`

Problem
=======

Keeping the Polkadot/api libraries in version sync is difficult and issues arise with dependencies in typescript with the additional requirement that `@frequency-chain/api-augment` versions align.

Solution
========
Removed the dependency need.